### PR TITLE
Migrate to Clang, LLVM's libc++ and C++23

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,7 +1,5 @@
 CompileFlags:
-    Add:
-        - "-std=c++20"
-        - "-fcoroutines-ts"
-    Remove:
-        - "-fcoroutines"
-        - "-fconcepts"
+  Add:
+    - "-std=c++23"
+  Remove:
+    - "-fconcepts"

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: "16"
+          clang-format-version: "17"
           check-path: "daemon"
 
   prettier:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
     "tamasfe.even-better-toml",
     "tdennis4496.cmantic",
     "twxs.cmake",
-    "xaver.clang-format"
+    "xaver.clang-format",
+    "vadimcn.vscode-lldb"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,39 +2,23 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "(lldb) Daemon",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [],
+      "cwd": "${command:cmake.getLaunchTargetDirectory}",
+      "env": {
+        "LD_LIBRARY_PATH": "./libs/",
+        "PATH": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+      }
+    },
+    {
       "name": "(yarn) Frontend",
       "command": "yarn start",
       "request": "launch",
       "type": "node-terminal",
       "cwd": "${workspaceFolder}/frontend"
-    },
-    {
-      "name": "(gdb) Daemon",
-      "type": "cppdbg",
-      "request": "launch",
-      "program": "${command:cmake.launchTargetPath}",
-      "args": [],
-      "stopAtEntry": false,
-      "cwd": "${command:cmake.getLaunchTargetDirectory}",
-      "environment": [
-        {
-          "name": "PATH",
-          "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
-        },
-        {
-          "name": "LD_LIBRARY_PATH",
-          "value": "./libs/"
-        }
-      ],
-      "externalConsole": false,
-      "MIMode": "gdb",
-      "setupCommands": [
-        {
-          "description": "Enable pretty-printing for gdb",
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        }
-      ]
     }
   ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,10 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wall -Wextra")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
 
 include(FetchContent)
 
@@ -40,6 +42,7 @@ endif()
 include("${CMAKE_BINARY_DIR}/conan.cmake")
 conan_cmake_run(CONANFILE conanfile.txt
     BASIC_SETUP
+    PROFILE default
     BUILD missing)
 
 add_subdirectory(daemon)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,23 @@ RUN apt-get update --yes && apt-get install --yes ca-certificates curl gnupg \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update --yes \
-    && apt-get install --yes build-essential git cmake libssl-dev pip ninja-build gdb clangd-17 clang-format-17 clang-17 nodejs zstd \
+    && apt-get install --yes build-essential git cmake libssl-dev pip ninja-build lldb-17 clangd-17 clang-format-17 clang-17 libc++-17-dev libc++-17-dev libc++abi-17-dev nodejs zstd \
     && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 100 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 100 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 100 && \
+    update-alternatives --set clang /usr/bin/clang-17 && \
+    update-alternatives --set clang++ /usr/bin/clang++-17 && \
+    update-alternatives --set cc /usr/bin/clang-17 && \
+    update-alternatives --set c++ /usr/bin/clang++-17
 
 RUN pip install conan==1.63.0 \
     && conan profile new default --detect \
-    && conan profile update settings.compiler.libcxx=libstdc++11 default
+    && conan profile update settings.compiler=clang default \
+    && conan profile update settings.compiler.version=17 default \
+    && conan profile update settings.compiler.libcxx=libc++ default
 
 RUN corepack enable \
     && corepack prepare yarn@stable --activate

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -18,7 +18,7 @@ nlohmann_json/3.11.2
 c-ares/1.19.1
 scnlib/1.1.2
 cereal/1.3.2
-libcoro/0.10
+libcoro/0.11.1
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -14,7 +14,6 @@ onetbb/2021.7.0
 drogon/1.8.2
 kangaru/4.3.0
 lmdb/0.9.29
-expected-lite/0.6.3
 nlohmann_json/3.11.2
 c-ares/1.19.1
 scnlib/1.1.2

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(bxtd LANGUAGES CXX)
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -fPIC -fopenmp -DBOOST -fcoroutines")
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath='$ORIGIN'")
-
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS "*.cpp")
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/daemon/core/domain/entities/Package.h
+++ b/daemon/core/domain/entities/Package.h
@@ -16,9 +16,8 @@
 #include "parallel_hashmap/phmap.h"
 #include "utilities/Error.h"
 
-#include <bits/ranges_algo.h>
+#include <expected>
 #include <filesystem>
-#include <nonstd/expected.hpp>
 #include <optional>
 #include <string>
 #include <unordered_map>

--- a/daemon/core/domain/repositories/RepositoryBase.h
+++ b/daemon/core/domain/repositories/RepositoryBase.h
@@ -9,7 +9,6 @@
 #include "UnitOfWorkBase.h"
 #include "core/domain/events/EventBase.h"
 #include "frozen/unordered_map.h"
-#include "nonstd/expected.hpp"
 #include "utilities/Error.h"
 #include "utilities/errors/Macro.h"
 
@@ -17,6 +16,7 @@
 #include <coro/sync_wait.hpp>
 #include <coro/task.hpp>
 #include <coro/when_all.hpp>
+#include <expected>
 #include <functional>
 #include <span>
 #include <vector>

--- a/daemon/core/domain/repositories/UnitOfWorkBase.h
+++ b/daemon/core/domain/repositories/UnitOfWorkBase.h
@@ -12,8 +12,7 @@
 
 #include <coro/sync_wait.hpp>
 #include <coro/task.hpp>
-#include <functional>
-#include <nonstd/expected.hpp>
+#include <expected>
 
 namespace bxt::Core::Domain {
 struct UnitOfWorkBase {

--- a/daemon/core/domain/value_objects/PackageVersion.h
+++ b/daemon/core/domain/value_objects/PackageVersion.h
@@ -7,10 +7,9 @@
 #pragma once
 
 #include "core/domain/value_objects/Name.h"
-#include "scn/scn.h"
-#include "scn/tuple_return/tuple_return.h"
 #include "utilities/Error.h"
 
+#include <expected>
 #include <fmt/format.h>
 #include <frozen/map.h>
 #include <frozen/string.h>
@@ -41,7 +40,7 @@ struct PackageVersion {
             message = error_messages.at(error_code).data();
         }
     };
-    using ParseResult = nonstd::expected<PackageVersion, ParsingError>;
+    using ParseResult = std::expected<PackageVersion, ParsingError>;
 
     static std::strong_ordering compare(const PackageVersion& lh,
                                         const PackageVersion& rh);

--- a/daemon/persistence/box/BoxRepository.cpp
+++ b/daemon/persistence/box/BoxRepository.cpp
@@ -146,7 +146,7 @@ coro::task<BoxRepository::TResult>
 }
 
 coro::task<UnitOfWorkBase::Result<void>> BoxRepository::commit_async() {
-    std::vector<coro::task<nonstd::expected<void, DatabaseError>>> tasks;
+    std::vector<coro::task<std::expected<void, DatabaseError>>> tasks;
 
     std::set<PackageSectionDTO> added_sections;
 

--- a/daemon/persistence/box/export/AlpmDBExporter.cpp
+++ b/daemon/persistence/box/export/AlpmDBExporter.cpp
@@ -16,7 +16,6 @@
 #include "utilities/log/Logging.h"
 
 #include <archive.h>
-#include <bits/ranges_algo.h>
 #include <coro/sync_wait.hpp>
 #include <filesystem>
 #include <iterator>

--- a/daemon/persistence/box/pool/Pool.cpp
+++ b/daemon/persistence/box/pool/Pool.cpp
@@ -16,15 +16,15 @@
 #include "utilities/to_string.h"
 
 #include <algorithm>
+#include <expected>
 #include <filesystem>
 #include <fmt/core.h>
 #include <iterator>
-#include <nonstd/expected.hpp>
 #include <string>
 #include <system_error>
 #include <vector>
 
-nonstd::expected<void, std::error_code>
+std::expected<void, std::error_code>
     move_file(const std::filesystem::path& from,
               const std::filesystem::path& to) {
     std::error_code ec;
@@ -39,7 +39,7 @@ nonstd::expected<void, std::error_code>
         if (!ec) { std::filesystem::remove(from, ec); }
     }
     if (ec.value() != 0) {
-        return nonstd::make_unexpected(ec);
+        return std::unexpected(ec);
     } else {
         return {};
     }

--- a/daemon/persistence/box/store/LMDBPackageStore.cpp
+++ b/daemon/persistence/box/store/LMDBPackageStore.cpp
@@ -22,7 +22,7 @@ LMDBPackageStore::LMDBPackageStore(
     : m_root_path(box_options.box_path), m_pool(pool), m_db(env, name) {
 }
 
-coro::task<nonstd::expected<void, DatabaseError>>
+coro::task<std::expected<void, DatabaseError>>
     LMDBPackageStore::add(const PackageRecord package) {
     auto moved_package = m_pool.move_to(package);
 
@@ -53,7 +53,7 @@ coro::task<nonstd::expected<void, DatabaseError>>
     co_return {};
 }
 
-coro::task<nonstd::expected<void, DatabaseError>>
+coro::task<std::expected<void, DatabaseError>>
     LMDBPackageStore::remove(const PackageRecord::Id package_id) {
     auto result = co_await m_db.del(package_id.to_string());
 
@@ -69,7 +69,7 @@ coro::task<nonstd::expected<void, DatabaseError>>
     co_return {};
 }
 
-coro::task<nonstd::expected<std::vector<PackageRecord>, DatabaseError>>
+coro::task<std::expected<std::vector<PackageRecord>, DatabaseError>>
     LMDBPackageStore::find_by_section(PackageSectionDTO section) {
     std::vector<PackageRecord> result;
 

--- a/daemon/persistence/box/store/LMDBPackageStore.h
+++ b/daemon/persistence/box/store/LMDBPackageStore.h
@@ -34,13 +34,13 @@ public:
 
     ~LMDBPackageStore() override = default;
 
-    coro::task<nonstd::expected<void, DatabaseError>>
+    coro::task<std::expected<void, DatabaseError>>
         add(const PackageRecord package) override;
 
-    coro::task<nonstd::expected<void, DatabaseError>>
+    coro::task<std::expected<void, DatabaseError>>
         remove(const PackageRecord::Id package_id) override;
 
-    coro::task<nonstd::expected<std::vector<PackageRecord>, DatabaseError>>
+    coro::task<std::expected<std::vector<PackageRecord>, DatabaseError>>
         find_by_section(PackageSectionDTO section) override;
 
     coro::task<void>

--- a/daemon/persistence/box/store/PackageStoreBase.h
+++ b/daemon/persistence/box/store/PackageStoreBase.h
@@ -19,14 +19,13 @@ namespace bxt::Persistence::Box {
 struct PackageStoreBase {
     virtual ~PackageStoreBase() = default;
 
-    virtual coro::task<nonstd::expected<void, DatabaseError>>
+    virtual coro::task<std::expected<void, DatabaseError>>
         add(const PackageRecord package) = 0;
 
-    virtual coro::task<nonstd::expected<void, DatabaseError>>
+    virtual coro::task<std::expected<void, DatabaseError>>
         remove(const PackageRecord::Id package_id) = 0;
 
-    virtual coro::task<
-        nonstd::expected<std::vector<PackageRecord>, DatabaseError>>
+    virtual coro::task<std::expected<std::vector<PackageRecord>, DatabaseError>>
         find_by_section(PackageSectionDTO section) = 0;
 
     virtual coro::task<void>

--- a/daemon/persistence/lmdb/LmdbRepository.h
+++ b/daemon/persistence/lmdb/LmdbRepository.h
@@ -13,7 +13,6 @@
 #include "core/domain/repositories/UnitOfWorkBase.h"
 #include "coro/task.hpp"
 #include "coro/when_all.hpp"
-#include "nonstd/expected.hpp"
 #include "utilities/Error.h"
 #include "utilities/StaticDTOMapper.h"
 #include "utilities/errors/DatabaseError.h"

--- a/daemon/utilities/Error.h
+++ b/daemon/utilities/Error.h
@@ -6,10 +6,9 @@
  */
 #pragma once
 #include "fmt/format.h"
-#include "nonstd/expected.hpp"
 
+#include <expected>
 #include <memory>
-#include <stdexcept>
 #include <string>
 
 namespace bxt {
@@ -63,20 +62,20 @@ struct Error {
 };
 
 template<typename TError, typename TSource, typename... TArgs>
-nonstd::unexpected<TError> make_error_with_source(TSource&& source,
-                                                  TArgs... ctorargs) {
+std::unexpected<TError> make_error_with_source(TSource&& source,
+                                               TArgs... ctorargs) {
     TError result(ctorargs...);
 
     result.source = std::make_unique<TSource>(std::move(source));
 
-    return nonstd::make_unexpected(result);
+    return std::unexpected(result);
 }
 
 template<typename TError, typename... TArgs>
-nonstd::unexpected<TError> make_error(TArgs... ctorargs) {
+std::unexpected<TError> make_error(TArgs... ctorargs) {
     TError result(ctorargs...);
 
-    return nonstd::make_unexpected(result);
+    return std::unexpected(result);
 }
 
 } // namespace bxt

--- a/daemon/utilities/alpmdb/Database.cpp
+++ b/daemon/utilities/alpmdb/Database.cpp
@@ -6,7 +6,6 @@
  */
 #include "Database.h"
 
-#include "nonstd/expected.hpp"
 #include "parallel_hashmap/phmap.h"
 #include "utilities/Error.h"
 #include "utilities/alpmdb/Desc.h"
@@ -20,6 +19,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <coro/latch.hpp>
 #include <execution>
+#include <expected>
 #include <filesystem>
 #include <fmt/format.h>
 #include <iterator>

--- a/daemon/utilities/alpmdb/Database.h
+++ b/daemon/utilities/alpmdb/Database.h
@@ -5,7 +5,6 @@
  *
  */
 #pragma once
-#include "nonstd/expected.hpp"
 #include "utilities/Error.h"
 #include "utilities/alpmdb/Desc.h"
 #include "utilities/errors/DatabaseError.h"
@@ -19,6 +18,7 @@
 #include <coro/mutex.hpp>
 #include <coro/sync_wait.hpp>
 #include <coro/task.hpp>
+#include <expected>
 #include <filesystem>
 #include <fmt/format.h>
 #include <frozen/map.h>

--- a/daemon/utilities/alpmdb/Desc.cpp
+++ b/daemon/utilities/alpmdb/Desc.cpp
@@ -6,12 +6,12 @@
  */
 #include "Desc.h"
 
-#include "nonstd/expected.hpp"
 #include "utilities/libarchive/Error.h"
 #include "utilities/libarchive/Reader.h"
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/iostreams/device/mapped_file.hpp>
+#include <expected>
 #include <fmt/format.h>
 #include <frozen/set.h>
 #include <frozen/string.h>
@@ -85,9 +85,8 @@ Desc::Result<Desc> Desc::parse_package(const std::filesystem::path &filepath) {
     const auto package_infos = file_reader.open_filename(filepath);
 
     if (!package_infos.has_value()) {
-        return nonstd::make_unexpected(
-            ParseError(ParseError::ErrorType::InvalidArchive,
-                       std::move(package_infos.error())));
+        return std::unexpected(ParseError(ParseError::ErrorType::InvalidArchive,
+                                          std::move(package_infos.error())));
     }
 
     PkgInfo infoObj;
@@ -109,11 +108,11 @@ Desc::Result<Desc> Desc::parse_package(const std::filesystem::path &filepath) {
             if (const auto invalidentry =
                     std::get_if<Archive::InvalidEntryError>(
                         &contents.error())) {
-                return nonstd::make_unexpected(
+                return std::unexpected(
                     ParseError(ParseError::ErrorType::InvalidArchive,
                                std::move(*invalidentry)));
             } else {
-                return nonstd::make_unexpected(
+                return std::unexpected(
                     ParseError(ParseError::ErrorType::InvalidArchive,
                                std::move(*std::get_if<Archive::LibArchiveError>(
                                    &contents.error()))));
@@ -124,7 +123,7 @@ Desc::Result<Desc> Desc::parse_package(const std::filesystem::path &filepath) {
     }
 
     if (!found) {
-        return nonstd::make_unexpected(
+        return std::unexpected(
             ParseError(ParseError::ErrorType::NoPackageInfo));
     }
 

--- a/daemon/utilities/alpmdb/Desc.h
+++ b/daemon/utilities/alpmdb/Desc.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "frozen/unordered_map.h"
-#include "nonstd/expected.hpp"
 #include "utilities/Error.h"
 #include "utilities/alpmdb/PkgInfo.h"
 #include "utilities/errors/Macro.h"
@@ -15,6 +14,7 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <cereal/access.hpp>
+#include <expected>
 #include <filesystem>
 #include <memory>
 #include <optional>

--- a/daemon/utilities/errors/Macro.h
+++ b/daemon/utilities/errors/Macro.h
@@ -5,9 +5,8 @@
  *
  */
 #pragma once
-
-#include <nonstd/expected.hpp>
+#include <expected>
 
 #define BXT_DECLARE_RESULT(error)        \
     template<typename TBxtExpectedValue> \
-    using Result = nonstd::expected<TBxtExpectedValue, error>;
+    using Result = std::expected<TBxtExpectedValue, error>;

--- a/daemon/utilities/libarchive/Reader.cpp
+++ b/daemon/utilities/libarchive/Reader.cpp
@@ -17,7 +17,7 @@ Reader::Result<void> Reader::open_filename(const std::filesystem::path &path) {
         archive_read_open_filename(m_archive.get(), path.c_str(), 1024);
 
     if (status != ARCHIVE_OK) {
-        return nonstd::make_unexpected(LibArchiveError(m_archive.get()));
+        return std::unexpected(LibArchiveError(m_archive.get()));
     }
 
     return {};
@@ -29,7 +29,7 @@ Reader::Result<void>
                                           byte_array.size());
 
     if (status != ARCHIVE_OK) {
-        return nonstd::make_unexpected(LibArchiveError(m_archive.get()));
+        return std::unexpected(LibArchiveError(m_archive.get()));
     }
 
     return {};
@@ -39,7 +39,7 @@ Reader::Result<void> Reader::open_memory(uint8_t *data, size_t length) {
     int status = archive_read_open_memory(m_archive.get(), data, length);
 
     if (status != ARCHIVE_OK) {
-        return nonstd::make_unexpected(LibArchiveError(m_archive.get()));
+        return std::unexpected(LibArchiveError(m_archive.get()));
     }
 
     return {};
@@ -56,7 +56,7 @@ Reader::Entry::Result<std::vector<uint8_t>> Reader::Entry::read_all() {
         const auto read_result = read_buffer(buffer, actual_size);
 
         if (!read_result.has_value()) {
-            return nonstd::make_unexpected(read_result.error());
+            return std::unexpected(read_result.error());
         }
 
         std::copy(buffer.begin(), buffer.begin() + actual_size,
@@ -68,7 +68,7 @@ Reader::Entry::Result<std::vector<uint8_t>> Reader::Entry::read_all() {
 
 Reader::Entry::Result<std::vector<uint8_t>>
     Reader::Entry::read(std::size_t amount) {
-    if (!m_reader) { return nonstd::make_unexpected(InvalidEntryError()); }
+    if (!m_reader) { return std::unexpected(InvalidEntryError()); }
 
     std::vector<uint8_t> result;
     result.resize(amount);
@@ -76,7 +76,7 @@ Reader::Entry::Result<std::vector<uint8_t>>
     const auto size = archive_read_data(m_reader, result.data(), amount);
 
     if (static_cast<int64_t>(size) < 0) {
-        return nonstd::make_unexpected(LibArchiveError(m_reader));
+        return std::unexpected(LibArchiveError(m_reader));
     }
 
     result.resize(size);

--- a/daemon/utilities/libarchive/Reader.h
+++ b/daemon/utilities/libarchive/Reader.h
@@ -8,11 +8,11 @@
 
 #include "Error.h"
 #include "Header.h"
-#include "nonstd/expected.hpp"
 #include "utilities/errors/Macro.h"
 
 #include <archive.h>
 #include <array>
+#include <expected>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -28,22 +28,19 @@ public:
     class Entry {
         template<typename T>
         using Result =
-            nonstd::expected<T,
-                             std::variant<InvalidEntryError, LibArchiveError>>;
+            std::expected<T, std::variant<InvalidEntryError, LibArchiveError>>;
         friend class Reader;
 
     public:
         template<std::size_t amount>
         Result<void> read_buffer(std::array<uint8_t, amount>& buffer,
                                  std::size_t& actual) {
-            if (!m_reader) {
-                return nonstd::make_unexpected(InvalidEntryError());
-            }
+            if (!m_reader) { return std::unexpected(InvalidEntryError()); }
 
             actual = archive_read_data(m_reader, buffer.data(), amount);
 
             if (static_cast<int64_t>(actual) < 0) {
-                return nonstd::make_unexpected(LibArchiveError(m_reader));
+                return std::unexpected(LibArchiveError(m_reader));
             }
 
             return {};
@@ -54,7 +51,7 @@ public:
 
         Result<void> skip() {
             if (archive_read_data_skip(m_reader) != ARCHIVE_OK) {
-                return nonstd::make_unexpected(LibArchiveError(m_reader));
+                return std::unexpected(LibArchiveError(m_reader));
             }
             return {};
         }

--- a/daemon/utilities/libarchive/Writer.cpp
+++ b/daemon/utilities/libarchive/Writer.cpp
@@ -7,7 +7,7 @@ Writer::Result<void> Writer::open_filename(const std::filesystem::path& path) {
         archive_write_open_filename(m_archive.get(), path.c_str());
 
     if (status != ARCHIVE_OK) {
-        return nonstd::make_unexpected(LibArchiveError(m_archive.get()));
+        return std::unexpected(LibArchiveError(m_archive.get()));
     }
 
     return {};
@@ -19,7 +19,7 @@ Writer::Result<void> Writer::open_memory(std::vector<std::byte>& byte_array,
         m_archive.get(), byte_array.data(), byte_array.size(), &used_size);
 
     if (status != ARCHIVE_OK) {
-        return nonstd::make_unexpected(LibArchiveError(m_archive.get()));
+        return std::unexpected(LibArchiveError(m_archive.get()));
     }
 
     return {};
@@ -29,7 +29,7 @@ Writer::Result<Writer::Entry> Writer::start_write(Header& header) {
     const int status = archive_write_header(m_archive.get(), header.entry());
 
     if (status != ARCHIVE_OK) {
-        return nonstd::make_unexpected(LibArchiveError(m_archive.get()));
+        return std::unexpected(LibArchiveError(m_archive.get()));
     }
 
     Entry entry;
@@ -43,7 +43,7 @@ Writer::Entry::Result<void>
     const auto status = archive_write_data(m_writer, data.data(), data.size());
 
     if (static_cast<int64_t>(status) < 0) {
-        return nonstd::make_unexpected(LibArchiveError(m_writer));
+        return std::unexpected(LibArchiveError(m_writer));
     }
 
     return {};

--- a/daemon/utilities/libarchive/Writer.h
+++ b/daemon/utilities/libarchive/Writer.h
@@ -11,9 +11,9 @@
 #include "utilities/errors/Macro.h"
 
 #include <archive.h>
+#include <expected>
 #include <filesystem>
 #include <memory>
-#include <nonstd/expected.hpp>
 #include <ostream>
 #include <variant>
 #include <vector>
@@ -33,20 +33,17 @@ public:
 
         template<typename T>
         using Result =
-            nonstd::expected<T,
-                             std::variant<InvalidEntryError, LibArchiveError>>;
+            std::expected<T, std::variant<InvalidEntryError, LibArchiveError>>;
 
         // Use the Result template for function return type
         Result<void> write(const std::vector<uint8_t>& data);
         Result<void> operator>>(const std::vector<uint8_t>& data);
 
         Result<void> finish() {
-            if (!m_writer) {
-                return nonstd::make_unexpected(InvalidEntryError {});
-            }
+            if (!m_writer) { return std::unexpected(InvalidEntryError {}); }
 
             if (archive_write_finish_entry(m_writer) != ARCHIVE_OK) {
-                return nonstd::make_unexpected(LibArchiveError(m_writer));
+                return std::unexpected(LibArchiveError(m_writer));
             }
             return {};
         }
@@ -74,7 +71,7 @@ private:
     static Result<void> deleter(archive* a) {
         const int status = archive_write_free(a);
         if (status != ARCHIVE_OK) {
-            return nonstd::make_unexpected(LibArchiveError(a));
+            return std::unexpected(LibArchiveError(a));
         }
         return {};
     }

--- a/daemon/utilities/lmdb/BoostSerializer.h
+++ b/daemon/utilities/lmdb/BoostSerializer.h
@@ -11,7 +11,6 @@
 #include "core/application/dtos/PackageSectionDTO.h"
 #include "core/application/dtos/UserDTO.h"
 #include "core/domain/entities/PackageLogEntry.h"
-#include "nonstd/expected.hpp"
 #include "utilities/Error.h"
 #include "utilities/errors/Macro.h"
 #include "utilities/lmdb/Error.h"
@@ -27,7 +26,7 @@ void boost::serialization::serialize(Archive &ar,
                                      std::filesystem::path &path,
                                      const unsigned int version) {
     std::string path_string = path.string();
-    ar &path_string;
+    ar & path_string;
     if (Archive::is_loading::value) {
         path = std::filesystem::path(path_string);
     }
@@ -38,27 +37,27 @@ void boost::serialization::serialize(
     Archive &ar,
     bxt::Core::Application::PackageSectionDTO &section,
     const unsigned int version) {
-    ar &section.branch;
-    ar &section.repository;
-    ar &section.architecture;
+    ar & section.branch;
+    ar & section.repository;
+    ar & section.architecture;
 }
 
 template<class Archive>
 void boost::serialization::serialize(Archive &ar,
                                      bxt::Core::Application::UserDTO &user,
                                      const unsigned int version) {
-    ar &user.name;
-    ar &user.password;
-    ar &user.permissions;
+    ar & user.name;
+    ar & user.password;
+    ar & user.permissions;
 }
 
 template<class Archive>
 void boost::serialization::serialize(Archive &ar,
                                      bxt::Core::Application::PackageDTO &pkg,
                                      const unsigned int version) {
-    ar &pkg.name;
-    ar &pkg.filepath;
-    ar &pkg.section;
+    ar & pkg.name;
+    ar & pkg.filepath;
+    ar & pkg.section;
 }
 
 template<class Archive>
@@ -66,10 +65,10 @@ void boost::serialization::serialize(
     Archive &ar,
     bxt::Core::Application::PackageLogEntryDTO &entry,
     const unsigned int version) {
-    ar &entry.id;
-    ar &entry.package;
-    ar &entry.time;
-    ar &entry.type;
+    ar & entry.id;
+    ar & entry.package;
+    ar & entry.time;
+    ar & entry.type;
 }
 
 namespace bxt::Utilities::LMDB {

--- a/daemon/utilities/lmdb/Database.h
+++ b/daemon/utilities/lmdb/Database.h
@@ -9,7 +9,6 @@
 #include "core/application/errors/CrudError.h"
 #include "coro/sync_wait.hpp"
 #include "lmdb.h"
-#include "nonstd/expected.hpp"
 #include "utilities/Error.h"
 #include "utilities/NavigationAction.h"
 #include "utilities/errors/DatabaseError.h"
@@ -19,6 +18,7 @@
 
 #include <exception>
 #include <lmdbxx/lmdb++.h>
+#include <string_view>
 namespace bxt::Utilities::LMDB {
 
 template<typename TEntity, typename TSerializer = CerealSerializer<TEntity>>


### PR DESCRIPTION
This will allow us to use latest features such as ranges and expected without adding third-party dependencies