### PR TITLE
fix(daemon): Check cookie token in verify endpoint

### DIFF
--- a/daemon/presentation/web-controllers/AuthController.h
+++ b/daemon/presentation/web-controllers/AuthController.h
@@ -23,7 +23,7 @@ public:
     METHOD_LIST_BEGIN
 
     BXT_ADD_METHOD_TO(AuthController::auth, "/api/auth", drogon::Post);
-    BXT_JWT_ADD_METHOD_TO(AuthController::verify, "/api/verify", drogon::Get);
+    BXT_ADD_METHOD_TO(AuthController::verify, "/api/verify", drogon::Get);
 
     METHOD_LIST_END
 


### PR DESCRIPTION
Previously `verify` was looking for bearer token.

This endpoint is a merely placeholder for the available permissions and other data report so it was unnoticed when the token storage mechanism was changed.