### PR TITLE
Expose ALPM DB over HTTP

### DIFF
--- a/daemon/persistence/box/export/AlpmDBExporter.cpp
+++ b/daemon/persistence/box/export/AlpmDBExporter.cpp
@@ -37,7 +37,6 @@ std::expected<void, FsError>
                   std::generic_category());
         return bxt::make_error<FsError>(ec);
     }
-    if (ec) { return bxt::make_error<FsError>(ec); }
 
     const auto relative_target =
         std::filesystem::relative(target, link.parent_path(), ec);

--- a/daemon/persistence/box/export/AlpmDBExporter.cpp
+++ b/daemon/persistence/box/export/AlpmDBExporter.cpp
@@ -104,10 +104,19 @@ coro::task<void> AlpmDBExporter::export_to_disk() {
 
                 const auto& [section, name] = *deserialized;
 
+                const auto preferred_location =
+                    Core::Domain::select_preferred_pool_location(
+                        package.descriptions);
+
+                if (!preferred_location.has_value()) {
+                    loge("Can't find preferred location for {}. "
+                         "Skipping.",
+                         name);
+                    return Utilities::NavigationAction::Next;
+                }
+
                 const auto version =
-                    package.descriptions
-                        .at(*Core::Domain::select_preferred_pool_location(
-                            package.descriptions))
+                    package.descriptions.at(*preferred_location)
                         .descfile.get("VERSION");
 
                 if (!version.has_value()) {

--- a/daemon/persistence/box/export/AlpmDBExporter.cpp
+++ b/daemon/persistence/box/export/AlpmDBExporter.cpp
@@ -8,15 +8,15 @@
 
 #include "core/application/dtos/PackageSectionDTO.h"
 #include "core/domain/enums/PoolLocation.h"
-#include "persistence/box/record/PackageRecord.h"
-#include "persistence/box/store/PackageStoreBase.h"
+#include "utilities/Error.h"
+#include "utilities/NavigationAction.h"
 #include "utilities/alpmdb/Database.h"
-#include "utilities/libarchive/Writer.h"
-#include "utilities/lmdb/Database.h"
-#include "utilities/log/Logging.h"
+#include "utilities/errors/FsError.h"
+#include "utilities/libarchive/Error.h"
 
 #include <archive.h>
 #include <coro/sync_wait.hpp>
+#include <expected>
 #include <filesystem>
 #include <iterator>
 #include <memory>
@@ -76,7 +76,9 @@ coro::task<void> AlpmDBExporter::export_to_disk() {
         logi("Exporter: \"{}\" export into the package manager format started",
              std::string(section));
 
-        auto writer = setup_writer(section);
+        /// TODO: We need to make this way more robust. At least a full backup
+        /// would work but maybe we can do something more smart...
+        auto writer = setup_alpmdb_writer(section);
 
         if (!writer.has_value()) {
             logf("Exporter: Writer cannot be created, the error is \"{}\". "
@@ -89,98 +91,13 @@ coro::task<void> AlpmDBExporter::export_to_disk() {
 
         co_await m_package_store.accept(
             [this, writer = &writers.at(section)](
-                std::string_view key,
-                const PackageRecord& package) -> Utilities::NavigationAction {
-                const auto deserialized = PackageRecord::Id::from_string(key);
-
-                if (!deserialized.has_value()) {
-                    loge("Exporter: Key \"{}\" is not valid. Skipping...", key);
+                std::string_view key, const PackageRecord& package) {
+                if (auto export_ok = export_package(*writer, key, package);
+                    !export_ok) {
+                    logf(fmt::format("Exporter: {}. Stopping...",
+                                     export_ok.error()));
                     return Utilities::NavigationAction::Stop;
                 }
-
-                const auto& [section, name] = *deserialized;
-
-                const auto preferred_location =
-                    Core::Domain::select_preferred_pool_location(
-                        package.descriptions);
-
-                if (!preferred_location.has_value()) {
-                    logf("Exporter: Can't find preferred location for \"{}\". "
-                         "Stopping...",
-                         name);
-                    return Utilities::NavigationAction::Stop;
-                }
-
-                const auto version =
-                    package.descriptions.at(*preferred_location)
-                        .descfile.get("VERSION");
-
-                if (!version.has_value()) {
-                    logf("Exporter: Version for \"{}\" is not valid. "
-                         "Stopping...",
-                         key);
-
-                    return Utilities::NavigationAction::Stop;
-                }
-
-                logi(
-                    "Exporter: Description for \"{}/{}-{}\" is being added... ",
-                    std::string(section), name, *version);
-
-                const auto preferred_description = package.descriptions.at(
-                    *Core::Domain::select_preferred_pool_location(
-                        package.descriptions));
-
-                if (auto write_ok = Utilities::AlpmDb::DatabaseUtils::
-                        write_buffer_to_archive(
-                            *writer, fmt::format("{}-{}/desc", name, *version),
-                            preferred_description.descfile.desc);
-                    !write_ok) {
-                    logf("Exporter: Can't write \"{}/{}-{}\" description to "
-                         "the archive. The error is \"{}\"",
-                         std::string(section), name, *version,
-                         write_ok.error().what());
-
-                    return Utilities::NavigationAction::Stop;
-                }
-
-                const auto filepath_link = std::filesystem::absolute(
-                    m_box_path / std::string(section)
-                    / preferred_description.filepath.filename());
-
-                if (auto link_created_ok = create_relative_symlink(
-                        preferred_description.filepath, filepath_link);
-                    !link_created_ok) {
-                    logf("Exporter: Can't link the package file for "
-                         "\"{}/{}-{}\". The error is \"{}\". Stopping the "
-                         "export...",
-                         std::string(section), name, *version,
-                         link_created_ok.error().what());
-
-                    return Utilities::NavigationAction::Stop;
-                }
-
-                if (preferred_description.signature_path) {
-                    const auto signature_link = std::filesystem::absolute(
-                        m_box_path / std::string(section)
-                        / preferred_description.signature_path->filename());
-
-                    if (auto link_created_ok = create_relative_symlink(
-                            *preferred_description.signature_path,
-                            signature_link);
-                        !link_created_ok) {
-                        logf("Exporter: Can't link the signature file for "
-                             "\"{}/{}-{}\". The error is \"{}\". Stopping the "
-                             "export...",
-                             std::string(section), name, *version,
-                             link_created_ok.error().what());
-
-                        return Utilities::NavigationAction::Stop;
-                    }
-                }
-
-                logi("Exporter: Description and link for \"{}/{}-{}\" is added",
-                     std::string(section), name, *version);
 
                 return Utilities::NavigationAction::Next;
             },
@@ -199,9 +116,9 @@ void AlpmDBExporter::add_dirty_sections(
     m_dirty_sections.insert(std::make_move_iterator(sections.begin()),
                             std::make_move_iterator(sections.end()));
 }
-
+// Factory function for ALPM .db archive writer
 std::expected<Archive::Writer, bxt::Error>
-    AlpmDBExporter::setup_writer(const PackageSectionDTO& section) {
+    AlpmDBExporter::setup_alpmdb_writer(const PackageSectionDTO& section) {
     Archive::Writer writer;
 
     if (archive_write_add_filter_zstd(writer) < ARCHIVE_WARN) {
@@ -229,6 +146,129 @@ std::expected<Archive::Writer, bxt::Error>
     }
 
     return writer;
+}
+
+struct PackageDetails {
+    PackageSectionDTO section;
+    std::string name;
+    std::string version;
+    PoolLocation preferred_location;
+};
+// Validates and extracts essential package details from both key and record
+std::expected<PackageDetails, std::string>
+    validate_package_key(std::string_view key, const PackageRecord& package) {
+    auto deserialized = PackageRecord::Id::from_string(key);
+    if (!deserialized.has_value()) {
+        return std::unexpected(fmt::format("Invalid package key: '{}'.", key));
+    }
+
+    const auto& [section, name] = *deserialized;
+
+    auto location = select_preferred_pool_location(package.descriptions);
+
+    if (!location.has_value()) {
+        return std::unexpected(
+            fmt::format("Can't select preferred location for '{}'", key));
+    }
+
+    std::optional<std::string> version_string;
+
+    auto description_it = package.descriptions.find(*location);
+    if (description_it == package.descriptions.end()) {
+        return std::unexpected(fmt::format(
+            "Package details not found for preferred location: '{}'.", key));
+    }
+    if (!(version_string = description_it->second.descfile.get("VERSION"))
+             .has_value()
+        || version_string->empty()) {
+        return std::unexpected(
+            fmt::format("No valid version for package '{}'.", key));
+    }
+    return PackageDetails {section, name, *version_string, *location};
+}
+
+// Writes the contents of package description file to section's ALPM Database
+// archive
+std::expected<void, std::string>
+    write_package_description_to_alpmdb(Archive::Writer& alpmdb_writer,
+                                        const PackageDetails& details,
+                                        const PackageRecord& package) {
+    const auto& [section, name, version, preferred_location] = details;
+    auto desc = package.descriptions.at(preferred_location).descfile.desc;
+    auto desc_path = fmt::format("{}-{}/desc", name, version);
+
+    if (auto write_ok =
+            Utilities::AlpmDb::DatabaseUtils::write_buffer_to_archive(
+                alpmdb_writer, desc_path, desc);
+        !write_ok) {
+        return std::unexpected(
+            fmt::format("Failed to write description for '{}/{}-{}'.",
+                        std::string(section), name, version));
+    }
+    return {};
+}
+
+// Symlinks (usually pool) package and optionally it's signature to the
+// specified section
+std::expected<void, std::string>
+    symlink_package_files(const PackageDetails& details,
+                          const PackageRecord& package,
+                          const std::filesystem::path& box_path) {
+    auto [section, name, version, preferred_location] = details;
+
+    auto description = package.descriptions.at(preferred_location);
+
+    auto link_file_path = std::filesystem::absolute(
+        box_path / std::string(section) / description.filepath.filename());
+
+    if (auto link_ok =
+            create_relative_symlink(description.filepath, link_file_path);
+        !link_ok) {
+        return std::unexpected(
+            fmt::format("Failed to link package file for '{}/{}-{}'.",
+                        std::string(section), name, version));
+    }
+
+    if (description.signature_path.has_value()) {
+        auto link_file_path =
+            std::filesystem::absolute(box_path / std::string(section)
+                                      / description.signature_path->filename());
+
+        if (auto link_ok = create_relative_symlink(*description.signature_path,
+                                                   link_file_path);
+            !link_ok) {
+            return std::unexpected(
+                fmt::format("Failed to link signature file for '{}/{}-{}'.",
+                            std::string(section), name, version));
+        }
+    }
+    return {};
+}
+// Exports package into the ALPM repository format by writing it's description
+// into the .db file and symlinking package and signature files for specified
+// section
+std::expected<void, std::string>
+    AlpmDBExporter::export_package(Archive::Writer& writer,
+                                   std::string_view key,
+                                   const PackageRecord& package) {
+    auto validated_details = validate_package_key(key, package);
+    if (!validated_details.has_value()) {
+        return std::unexpected(validated_details.error());
+    }
+
+    auto write_result = write_package_description_to_alpmdb(
+        writer, *validated_details, package);
+    if (!write_result.has_value()) {
+        return std::unexpected(write_result.error());
+    }
+
+    auto file_management_result =
+        symlink_package_files(*validated_details, package, m_box_path);
+    if (!file_management_result.has_value()) {
+        return std::unexpected(file_management_result.error());
+    }
+
+    return {};
 }
 
 } // namespace bxt::Persistence::Box

--- a/daemon/persistence/box/export/AlpmDBExporter.cpp
+++ b/daemon/persistence/box/export/AlpmDBExporter.cpp
@@ -24,17 +24,20 @@
 #include <parallel_hashmap/phmap.h>
 #include <string_view>
 #include <system_error>
-#include <thread>
-#include <unordered_map>
-#include <utility>
 
 namespace bxt::Persistence::Box {
-
+// Creates the symlink relative to target
 std::expected<void, FsError>
     create_relative_symlink(const std::filesystem::path& target,
                             const std::filesystem::path& link) {
-    if (std::filesystem::is_symlink(link)) { return {}; }
     std::error_code ec;
+
+    if (std::filesystem::exists(link)) {
+        ec.assign(static_cast<int>(std::errc::file_exists),
+                  std::generic_category());
+        return bxt::make_error<FsError>(ec);
+    }
+    if (ec) { return bxt::make_error<FsError>(ec); }
 
     const auto relative_target =
         std::filesystem::relative(target, link.parent_path(), ec);

--- a/daemon/persistence/box/export/AlpmDBExporter.h
+++ b/daemon/persistence/box/export/AlpmDBExporter.h
@@ -13,7 +13,8 @@
 #include "persistence/box/BoxOptions.h"
 #include "persistence/box/export/ExporterBase.h"
 #include "persistence/box/store/PackageStoreBase.h"
-#include "utilities/locked.h"
+#include "utilities/libarchive/Error.h"
+#include "utilities/libarchive/Writer.h"
 
 #include <coro/io_scheduler.hpp>
 #include <filesystem>
@@ -34,6 +35,8 @@ public:
         std::set<Core::Application::PackageSectionDTO>&& override) override;
 
 private:
+    std::expected<Archive::Writer, Archive::LibArchiveError>
+        setup_writer(const PackageSectionDTO& section);
     std::filesystem::path m_box_path;
     std::set<Core::Application::PackageSectionDTO> m_sections;
     PackageStoreBase& m_package_store;

--- a/daemon/persistence/box/export/AlpmDBExporter.h
+++ b/daemon/persistence/box/export/AlpmDBExporter.h
@@ -8,13 +8,14 @@
 #pragma once
 
 #include "core/application/dtos/PackageSectionDTO.h"
+#include "core/domain/entities/Section.h"
 #include "core/domain/repositories/RepositoryBase.h"
 #include "parallel_hashmap/phmap.h"
 #include "persistence/box/BoxOptions.h"
 #include "persistence/box/export/ExporterBase.h"
 #include "persistence/box/store/PackageStoreBase.h"
 #include "utilities/Error.h"
-#include "utilities/libarchive/Error.h"
+#include "utilities/errors/FsError.h"
 #include "utilities/libarchive/Writer.h"
 
 #include <coro/io_scheduler.hpp>
@@ -37,7 +38,13 @@ public:
 
 private:
     std::expected<Archive::Writer, bxt::Error>
-        setup_writer(const PackageSectionDTO& section);
+        setup_alpmdb_writer(const PackageSectionDTO& section);
+
+    std::expected<void, std::string>
+        export_package(Archive::Writer& writer,
+                       std::string_view key,
+                       const PackageRecord& package);
+
     std::filesystem::path m_box_path;
     std::set<Core::Application::PackageSectionDTO> m_sections;
     PackageStoreBase& m_package_store;

--- a/daemon/persistence/box/export/AlpmDBExporter.h
+++ b/daemon/persistence/box/export/AlpmDBExporter.h
@@ -13,6 +13,7 @@
 #include "persistence/box/BoxOptions.h"
 #include "persistence/box/export/ExporterBase.h"
 #include "persistence/box/store/PackageStoreBase.h"
+#include "utilities/Error.h"
 #include "utilities/libarchive/Error.h"
 #include "utilities/libarchive/Writer.h"
 
@@ -35,7 +36,7 @@ public:
         std::set<Core::Application::PackageSectionDTO>&& override) override;
 
 private:
-    std::expected<Archive::Writer, Archive::LibArchiveError>
+    std::expected<Archive::Writer, bxt::Error>
         setup_writer(const PackageSectionDTO& section);
     std::filesystem::path m_box_path;
     std::set<Core::Application::PackageSectionDTO> m_sections;

--- a/daemon/persistence/box/export/AlpmDBExporter.h
+++ b/daemon/persistence/box/export/AlpmDBExporter.h
@@ -40,6 +40,9 @@ private:
     std::expected<Archive::Writer, bxt::Error>
         setup_alpmdb_writer(const PackageSectionDTO& section);
 
+    std::expected<void, FsError>
+        cleanup_section(const PackageSectionDTO& section);
+
     std::expected<void, std::string>
         export_package(Archive::Writer& writer,
                        std::string_view key,

--- a/daemon/utilities/errors/FsError.h
+++ b/daemon/utilities/errors/FsError.h
@@ -1,0 +1,15 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+#include "utilities/Error.h"
+
+#include <system_error>
+namespace bxt {
+struct FsError : public bxt::Error {
+    FsError(const std::error_code& ec) { message = ec.message(); }
+};
+} // namespace bxt

--- a/daemon/utilities/libarchive/Error.h
+++ b/daemon/utilities/libarchive/Error.h
@@ -14,14 +14,17 @@
 
 namespace Archive {
 
-struct InvalidEntryError : public bxt::Error {
+struct ArchiveError : public bxt::Error {
+    ArchiveError() { message = "Unknown Archive error"; }
+};
+
+struct InvalidEntryError : public ArchiveError {
     InvalidEntryError() { message = "The entry has no linked archive!"; }
 };
 
-struct LibArchiveError : public bxt::Error {
+struct LibArchiveError : public ArchiveError {
     explicit LibArchiveError(archive* archive) {
         message = archive_error_string(archive);
     }
 };
-
 } // namespace Archive

--- a/daemon/utilities/libarchive/Writer.h
+++ b/daemon/utilities/libarchive/Writer.h
@@ -31,9 +31,7 @@ public:
     public:
         Entry() = default;
 
-        template<typename T>
-        using Result =
-            std::expected<T, std::variant<InvalidEntryError, LibArchiveError>>;
+        template<typename T> using Result = std::expected<T, ArchiveError>;
 
         // Use the Result template for function return type
         Result<void> write(const std::vector<uint8_t>& data);

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - caddy_data:/data
-      - persistence_volume: /persistence
+      - persistence_volume:/persistence
     restart: unless-stopped
   production:
     ports: !reset []

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - caddy_data:/data
+      - persistence_volume: /persistence
     restart: unless-stopped
   production:
     ports: !reset []
@@ -19,6 +20,9 @@ services:
     labels:
       caddy: "${CADDY_HOST}"
       caddy.reverse_proxy: "{{upstreams 8080}}"
+      caddy.1_handle_path: "/box/*"
+      caddy.1_handle_path.root: "* /persistence/box"
+      caddy.1_handle_path.file_server: "browse"
     depends_on:
       - caddy
 


### PR DESCRIPTION
This PR is primarily for exposing ALPM/pacman database over HTTP using Caddy, but also it improves the LMDB->ALPM export logic and refactors it.