### PR TITLE
Refactor public API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 project(bxt CXX)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ if(NOT event-bus_POPULATED)
     add_subdirectory(${event-bus_SOURCE_DIR}/lib ${event-bus_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif(NOT event-bus_POPULATED)
 
+FetchContent_Declare(
+    reflect-cpp
+    GIT_REPOSITORY https://github.com/getml/reflect-cpp.git
+    GIT_TAG v0.10.0
+    GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(reflect-cpp)
 
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update --yes && apt-get install --yes ca-certificates curl gnupg \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && curl --silent --location https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg \
+    &&  echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
     && apt-get update --yes \
     && apt-get install --yes build-essential git cmake libssl-dev pip ninja-build lldb-17 clangd-17 clang-format-17 clang-17 libc++-17-dev libc++abi-17-dev nodejs zstd \
     && rm -rf /var/lib/apt/lists/*

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/bin)
 target_link_libraries(${PROJECT_NAME}
     ${CONAN_LIBS}
     Dexode::EventBus
+    reflectcpp
 )
 
 add_dependencies(${PROJECT_NAME} deploy_swagger)

--- a/daemon/core/application/dtos/PackageSectionDTO.h
+++ b/daemon/core/application/dtos/PackageSectionDTO.h
@@ -65,3 +65,8 @@ template<> struct std::hash<PackageSectionDTO> {
         return seed;
     }
 };
+
+template<> inline std::string bxt::to_string(const PackageSectionDTO& dto) {
+    return fmt::format("{}/{}/{}", dto.branch, dto.repository,
+                       dto.architecture);
+}

--- a/daemon/core/domain/enums/LogEntryType.h
+++ b/daemon/core/domain/enums/LogEntryType.h
@@ -8,6 +8,6 @@
 
 namespace bxt::Core::Domain {
 
-enum LogEntryType { Add, Remove, Update };
+enum class LogEntryType { Add, Remove, Update };
 
 } // namespace bxt::Core::Domain

--- a/daemon/presentation/messages/AuthMessages.h
+++ b/daemon/presentation/messages/AuthMessages.h
@@ -1,0 +1,16 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+
+#include <string>
+
+namespace bxt::Presentation {
+struct AuthRequest {
+    std::string name;
+    std::string password;
+};
+} // namespace bxt::Presentation

--- a/daemon/presentation/messages/CompareMessages.h
+++ b/daemon/presentation/messages/CompareMessages.h
@@ -1,0 +1,27 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+
+#include "core/application/dtos/PackageSectionDTO.h"
+#include "presentation/messages/SectionMessages.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace bxt::Presentation {
+
+using CompareRequest = std::vector<SectionRequest>;
+
+using LocationMap = std::unordered_map<std::string, std::string>;
+using SectionMap = std::unordered_map<std::string, LocationMap>;
+
+struct CompareResponse {
+    std::vector<Core::Application::PackageSectionDTO> sections;
+    std::unordered_map<std::string, SectionMap> compare_table;
+};
+} // namespace bxt::Presentation

--- a/daemon/presentation/messages/LogMessages.h
+++ b/daemon/presentation/messages/LogMessages.h
@@ -1,0 +1,24 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+
+#include "core/domain/enums/LogEntryType.h"
+#include "presentation/messages/PackageMessages.h"
+
+#include <string>
+
+namespace bxt::Presentation {
+
+struct LogEntryReponse {
+    std::string id;
+    uint64_t time;
+    Core::Domain::LogEntryType type;
+    PackageResponse package;
+};
+
+using LogResponse = std::vector<LogEntryReponse>;
+} // namespace bxt::Presentation

--- a/daemon/presentation/messages/PackageMessages.h
+++ b/daemon/presentation/messages/PackageMessages.h
@@ -1,0 +1,33 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+
+#include "core/application/dtos/PackageSectionDTO.h"
+#include "presentation/messages/SectionMessages.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace bxt::Presentation {
+
+struct SnapRequest {
+    SectionRequest source;
+    SectionRequest target;
+};
+
+struct PoolEntryResponse {
+    std::string version;
+    bool has_signature;
+};
+
+struct PackageResponse {
+    std::string name;
+    Core::Application::PackageSectionDTO section;
+    std::unordered_map<std::string, PoolEntryResponse> pool_entries;
+    std::string preferred_location;
+};
+} // namespace bxt::Presentation

--- a/daemon/presentation/messages/SectionMessages.h
+++ b/daemon/presentation/messages/SectionMessages.h
@@ -1,0 +1,17 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+
+#include "core/application/dtos/PackageSectionDTO.h"
+
+namespace bxt::Presentation {
+
+using SectionRequest = Core::Application::PackageSectionDTO;
+
+using SectionReponse = Core::Application::PackageSectionDTO;
+
+} // namespace bxt::Presentation

--- a/daemon/presentation/messages/UserMessages.h
+++ b/daemon/presentation/messages/UserMessages.h
@@ -1,0 +1,34 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+
+#include <optional>
+#include <set>
+#include <string>
+
+namespace bxt::Presentation {
+struct AddUserRequest {
+    std::string name;
+    std::string password;
+    std::optional<std::set<std::string>> permissions;
+};
+
+struct UpdateUserRequest {
+    std::string name;
+    std::optional<std::string> password;
+    std::optional<std::set<std::string>> permissions;
+};
+
+struct RemoveUserRequest {
+    std::string name;
+};
+
+struct UserResponse {
+    std::string name;
+    std::set<std::string> permissions;
+};
+} // namespace bxt::Presentation

--- a/daemon/presentation/web-controllers/PackageController.h
+++ b/daemon/presentation/web-controllers/PackageController.h
@@ -38,12 +38,16 @@ public:
 
     BXT_JWT_ADD_METHOD_TO(
         PackageController::get_packages,
-        "/api/packages/get?branch={1}&repository={2}&architecture={3}",
+        "/api/packages?branch={1}&repository={2}&architecture={3}",
         drogon::Get);
 
-    BXT_JWT_ADD_METHOD_TO(PackageController::sync, "/api/sync", drogon::Post);
+    BXT_JWT_ADD_METHOD_TO(PackageController::sync,
+                          "/api/packages/sync",
+                          drogon::Post);
 
-    BXT_JWT_ADD_METHOD_TO(PackageController::snap, "/api/snap", drogon::Post);
+    BXT_JWT_ADD_METHOD_TO(PackageController::snap,
+                          "/api/packages/snap",
+                          drogon::Post);
 
     METHOD_LIST_END
 

--- a/daemon/presentation/web-controllers/SectionController.h
+++ b/daemon/presentation/web-controllers/SectionController.h
@@ -25,7 +25,7 @@ public:
     METHOD_LIST_BEGIN
 
     BXT_JWT_ADD_METHOD_TO(SectionController::get_sections,
-                          "/api/sections/get",
+                          "/api/sections",
                           drogon::Get);
 
     METHOD_LIST_END

--- a/daemon/presentation/web-filters/JwtFilter.cpp
+++ b/daemon/presentation/web-filters/JwtFilter.cpp
@@ -6,10 +6,20 @@
  */
 #include "JwtFilter.h"
 
+#include "utilities/drogon/Helpers.h"
+
+#include <expected>
 #include <jwt-cpp/traits/nlohmann-json/defaults.h>
 
 namespace bxt::Presentation {
 using namespace drogon;
+
+std::expected<jwt::decoded_jwt<jwt::traits::nlohmann_json>, std::exception>
+    decode_jwt(const std::string &token) {
+    try {
+        return jwt::decode(token);
+    } catch (std::exception &e) { return std::unexpected(e); }
+}
 
 void JwtFilter::doFilter(const HttpRequestPtr &request,
                          FilterCallback &&fcb,
@@ -19,38 +29,33 @@ void JwtFilter::doFilter(const HttpRequestPtr &request,
     std::string token = request->getCookie("token");
 
     if (token.empty()) {
-        Json::Value resultJson;
-        resultJson["error"] =
-            "Authentification header is not found or malformed";
-        resultJson["status"] = "error";
-
-        auto res = HttpResponse::newHttpJsonResponse(resultJson);
-        res->setStatusCode(k401Unauthorized);
-
-        return fcb(res);
+        return fcb(drogon_helpers::make_error_response(
+            "Authentification header is not found", k401Unauthorized));
     }
 
-    auto decoded = jwt::decode(token);
     auto verifier =
         jwt::verify()
             .allow_algorithm(jwt::algorithm::hs256 {m_options.secret})
             .with_issuer("auth0");
 
+    auto decoded = decode_jwt(token);
+
+    if (!decoded.has_value()) {
+        return fcb(drogon_helpers::make_error_response(
+            fmt::format("Error while decoding the token: {}",
+                        decoded.error().what()),
+            k401Unauthorized));
+    }
+
     std::error_code ec;
 
-    verifier.verify(decoded, ec);
+    verifier.verify(*decoded, ec);
 
     if (ec) {
-        Json::Value resultJson;
-        resultJson["message"] = "Token is invalid!";
-        resultJson["status"] = "error";
-
-        auto res = HttpResponse::newHttpJsonResponse(resultJson);
-        res->setStatusCode(k401Unauthorized);
-
-        return fcb(res);
+        return fcb(drogon_helpers::make_error_response(
+            "Authentification token is invalid", k401Unauthorized));
     }
-    auto claims = decoded.get_payload_claims();
+    auto claims = decoded->get_payload_claims();
 
     for (auto &claim : claims)
         request->getAttributes()->insert("jwt_" + claim.first,

--- a/daemon/swagger/openapi.yml.in
+++ b/daemon/swagger/openapi.yml.in
@@ -2,176 +2,78 @@ openapi: 3.0.0
 info:
   title: b[x]t API
   description: API for the b[x]t repository management service.
-  version: "0.1"
+  version: "MVP"
 servers:
   - url: "/"
 paths:
   /api/auth:
     post:
-      summary: Authentificate user.
+      summary: Authenticate user
+      operationId: auth
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - name
-                - password
-              properties:
-                name:
-                  type: string
-                password:
-                  type: string
+              $ref: "#/components/schemas/AuthRequest"
       responses:
         "200":
-          description: Issued JWT after successful authentification.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  token:
-                    type: string
+          description: Authentication successful, JWT token set in cookie
         "400":
-          description: Data is malformed.
+          description: Invalid request
         "401":
-          description: Credentials are invalid.
+          description: Unauthorized
   /api/verify:
     get:
-      summary: Verify issued token.
+      summary: Verify JWT token
+      operationId: verify
       responses:
         "200":
-          description: JWT is valid.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    example: "ok"
-        "401":
-          description: Token is invalid or expired.
-
-  /api/users/add:
-    post:
-      summary: Add a new user.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-              properties:
-                name:
-                  type: string
-                password:
-                  type: string
-                permissions:
-                  type: array
-                  items:
-                    type: string
-      responses:
-        "200":
-          description: User added successfully.
+          description: Token is valid
         "400":
-          description: Data is missing or malformed.
+          description: Invalid request
         "401":
-          description: User lacks permissions.
-
-  /api/users/update:
-    post:
-      summary: Update an existing user.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-              properties:
-                name:
-                  type: string
-                password:
-                  type: string
-                permissions:
-                  type: array
-                  items:
-                    type: string
-      responses:
-        "200":
-          description: User successfully updated.
-        "400":
-          description: Data is missing or malformed.
-        "401":
-          description: Lacks permissions.
-
-  /api/users/remove:
-    post:
-      summary: Remove an existing user.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - id
-              properties:
-                id:
-                  type: string
-      responses:
-        "200":
-          description: User successfully removed.
-        "400":
-          description: Data is missing or malformed.
-        "401":
-          description: Lacks permissions.
-
-  /api/users:
+          description: Unauthorized
+  /api/logs/packages:
     get:
-      summary: Retrieve a list of users.
+      summary: Get package logs
+      operationId: getPackageLogs
       responses:
         "200":
-          description: Retrieved list of users.
+          description: List of package log entries
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/User"
+                $ref: "#/components/schemas/LogResponse"
+        "400":
+          description: Invalid request
         "401":
-          description: User lacks permissions.
-
-  /api/sections/get:
-    get:
-      summary: Retrieve accessible sections based on user permissions.
-      responses:
-        "200":
-          description: Retrieved sections.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Section"
-        "401":
-          description: User lacks permissions.
-
-  /api/sync:
+          description: Unauthorized
+  /api/compare:
     post:
-      summary: Synchronize package data across the system.
+      summary: Compare sections
+      operationId: compare
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompareRequest"
       responses:
         "200":
-          description: Synchronization started successfully.
-
+          description: Comparison result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompareResponse"
+        "400":
+          description: Invalid request
+        "401":
+          description: Unauthorized
   /api/packages/commit:
     post:
-      summary: Commit a transaction.
+      summary: Commit package transaction
+      operationId: commitTransaction
       requestBody:
         required: true
         content:
@@ -179,53 +81,25 @@ paths:
             schema:
               type: object
               properties:
-                files:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      file:
-                        type: string
-                        format: binary
-                        description: The binary file of the package.
-                      signature:
-                        type: string
-                        format: binary
-                        description: The binary file of the package's signature.
-                packageInfo:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                        description: Name identifier of the package.
-                      branch:
-                        type: string
-                        description: Branch name for where the package should be committed.
-                      repository:
-                        type: string
-                        description: Repository name for where the package should be committed.
-                      architecture:
-                        type: string
-                        description: Architecture name for where the package should be committed.
+                packageFile:
+                  type: string
+                  format: binary
+                packageSignature:
+                  type: string
+                  format: binary
+                packageSection:
+                  type: string
       responses:
         "200":
-          description: Transaction committed successfully.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: string
-                    example: "ok"
+          description: Transaction committed successfully
         "400":
-          description: Data is missing or malformed.
-
-  /api/packages/get:
+          description: Invalid request
+        "401":
+          description: Unauthorized
+  /api/packages:
     get:
-      summary: Retrieve packages based on specified branch, repository, and architecture.
+      summary: Get packages by section
+      operationId: getPackages
       parameters:
         - name: branch
           in: query
@@ -244,119 +118,218 @@ paths:
             type: string
       responses:
         "200":
-          description: Retrieved packages.
+          description: List of packages
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Package"
-
-  /api/snap:
+                  $ref: "#/components/schemas/PackageResponse"
+        "400":
+          description: Invalid request
+        "401":
+          description: Unauthorized
+  /api/packages/sync:
     post:
-      summary: Snap packages from a source section to a target section.
+      summary: Synchronize packages
+      operationId: sync
+      responses:
+        "200":
+          description: Packages synchronized successfully
+        "400":
+          description: Invalid request
+        "401":
+          description: Unauthorized
+  /api/packages/snap:
+    post:
+      summary: Snap packages between branches
+      operationId: snap
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                source:
-                  $ref: "#/components/schemas/Section"
-                target:
-                  $ref: "#/components/schemas/Section"
+              $ref: "#/components/schemas/SnapRequest"
       responses:
         "200":
-          description: Snap operation successful.
-
-  /api/logs/packages:
+          description: Packages snapped successfully
+        "400":
+          description: Invalid request
+        "401":
+          description: Unauthorized
+  /api/sections:
     get:
-      summary: Retrieve logs for package-related actions.
+      summary: Get sections
+      operationId: getSections
       responses:
         "200":
-          description: Retrieved package logs.
+          description: List of sections
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/LogEntry"
-  /api/deploy/start:
-    post:
-      summary: Start a deployment session.
-      responses:
-        "200":
-          description: Deployment session started successfully.
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: "Session started with ID: {session_id}"
-        "401":
-          description: No API key provided or invalid API key.
+                  $ref: "#/components/schemas/SectionResponse"
         "400":
-          description: Error message if start failed.
-  /api/deploy/push:
+          description: Invalid request
+        "401":
+          description: Unauthorized
+  /api/users/add:
     post:
-      summary: Push a package to the deployment session.
+      summary: Add a new user
+      operationId: addUser
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
-              type: object
-              properties:
-                file:
-                  type: string
-                  format: binary
-                  description: The binary file of the package.
-                signature:
-                  type: string
-                  format: binary
-                  description: The binary signature of the package.
-                branch:
-                  type: string
-                  description: The branch where the package will be deployed.
-                repository:
-                  type: string
-                  description: The repository where the package will be deployed.
-                architecture:
-                  type: string
-                  description: The architecture of the package deployment.
-                session:
-                  type: string
-                  description: The session ID for the deployment.
+              $ref: "#/components/schemas/AddUserRequest"
       responses:
         "200":
-          description: Package pushed successfully.
+          description: User added successfully
         "400":
-          description: Invalid request, missing file, signature, or invalid section data.
+          description: Invalid request
         "401":
-          description: Invalid or missing API key.
-  /api/deploy/end:
+          description: Unauthorized
+  /api/users/update:
     post:
-      summary: End a deployment session.
+      summary: Update an existing user
+      operationId: updateUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateUserRequest"
       responses:
         "200":
-          description: Deployment session ended successfully.
+          description: User updated successfully
         "400":
-          description: Error message if ending the session failed.
+          description: Invalid request
         "401":
-          description: Invalid or missing API key.
+          description: Unauthorized
+  /api/users/remove:
+    post:
+      summary: Remove a user
+      operationId: removeUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemoveUserRequest"
+      responses:
+        "200":
+          description: User removed successfully
+        "400":
+          description: Invalid request
+        "401":
+          description: Unauthorized
+  /api/users:
+    get:
+      summary: Get list of users
+      operationId: getUsers
+      responses:
+        "200":
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/UserResponse"
+        "400":
+          description: Invalid request
+        "401":
+          description: Unauthorized
 
 components:
   schemas:
-    User:
+    AuthRequest:
       type: object
       properties:
         name:
           type: string
-        permissions:
+        password:
+          type: string
+      required:
+        - name
+        - password
+
+    CompareRequest:
+      type: array
+      items:
+        $ref: "#/components/schemas/SectionRequest"
+
+    CompareResponse:
+      type: object
+      properties:
+        sections:
           type: array
           items:
-            type: string
-    Section:
+            $ref: "#/components/schemas/PackageSection"
+        compareTable:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: object
+              additionalProperties:
+                type: string
+
+    LogResponse:
+      type: array
+      items:
+        $ref: "#/components/schemas/LogEntryResponse"
+
+    LogEntryResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        time:
+          type: integer
+          format: int64
+        type:
+          $ref: "#/components/schemas/LogEntryType"
+        package:
+          $ref: "#/components/schemas/PackageResponse"
+      required:
+        - id
+        - time
+        - type
+        - package
+
+    LogEntryType:
+      type: string
+      enum:
+        - Add
+        - Remove
+        - Update
+
+    PackageResponse:
+      type: object
+      properties:
+        name:
+          type: string
+        section:
+          type: string
+        poolEntries:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/PoolEntryResponse"
+        preferredLocation:
+          type: string
+
+    PoolEntryResponse:
+      type: object
+      properties:
+        version:
+          type: string
+        signaturePath:
+          type: boolean
+
+    PackageSection:
       type: object
       properties:
         branch:
@@ -365,32 +338,64 @@ components:
           type: string
         architecture:
           type: string
-    Package:
+      required:
+        - branch
+        - repository
+        - architecture
+
+    SectionRequest:
+      $ref: "#/components/schemas/PackageSection"
+
+    SectionResponse:
+      $ref: "#/components/schemas/PackageSection"
+
+    SnapRequest:
+      type: object
+      properties:
+        source:
+          $ref: "#/components/schemas/SectionRequest"
+        target:
+          $ref: "#/components/schemas/SectionRequest"
+      required:
+        - source
+        - target
+
+    AddUserRequest:
       type: object
       properties:
         name:
           type: string
-        section:
-          $ref: "#/components/schemas/Section"
-        pool_entries:
+        password:
+          type: string
+        permissions:
           type: array
           items:
-            $ref: "#/components/schemas/PoolEntry"
-    PoolEntry:
+            type: string
+
+    UpdateUserRequest:
       type: object
       properties:
-        version:
+        name:
           type: string
-        hasSignature:
-          type: boolean
-    LogEntry:
+        password:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+
+    RemoveUserRequest:
       type: object
       properties:
-        id:
+        name:
           type: string
-        time:
+
+    UserResponse:
+      type: object
+      properties:
+        name:
           type: string
-        package:
-          $ref: "#/components/schemas/Package"
-        action:
-          type: string
+        permissions:
+          type: array
+          items:
+            type: string

--- a/daemon/utilities/drogon/Helpers.h
+++ b/daemon/utilities/drogon/Helpers.h
@@ -7,10 +7,15 @@
 #pragma once
 
 #include "drogon/utils/FunctionTraits.h"
+#include "utilities/reflect/PathParser.h"
 
 #include "json/value.h"
+#include <drogon/HttpRequest.h>
 #include <drogon/HttpResponse.h>
 #include <drogon/HttpTypes.h>
+#include <rfl/SnakeCaseToCamelCase.hpp>
+#include <rfl/json/read.hpp>
+#include <rfl/json/write.hpp>
 
 namespace bxt::drogon_helpers {
 inline ::drogon::HttpResponsePtr make_error_response(
@@ -39,4 +44,20 @@ inline ::drogon::HttpResponsePtr
 
     return result;
 }
+
+// Use reflect-cpp to make json response
+template<typename T>
+inline ::drogon::HttpResponsePtr make_json_response(const T& value) {
+    auto result = ::drogon::HttpResponse::newHttpResponse();
+    result->setBody(rfl::json::write<rfl::SnakeCaseToCamelCase>(value));
+    result->setStatusCode(drogon::k200OK);
+
+    return result;
+}
+
+template<typename T> inline auto get_request_json(drogon::HttpRequestPtr req) {
+    return rfl::json::read<T, rfl::SnakeCaseToCamelCase>(
+        std::string(req->body()));
+}
+
 } // namespace bxt::drogon_helpers

--- a/daemon/utilities/reflect/PathParser.h
+++ b/daemon/utilities/reflect/PathParser.h
@@ -1,0 +1,32 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#pragma once
+#include <filesystem>
+#include <rfl/parsing/CustomParser.hpp>
+#include <string>
+
+struct Path {
+    std::string path;
+
+    static Path from_class(const std::filesystem::path& _p) noexcept {
+        return Path {_p.string()};
+    }
+    std::filesystem::path to_class() const {
+        return std::filesystem::path {path};
+    }
+};
+namespace rfl::parsing {
+
+template<class ReaderType, class WriterType, class ProcessorsType>
+struct Parser<ReaderType, WriterType, std::filesystem::path, ProcessorsType>
+    : public CustomParser<ReaderType,
+                          WriterType,
+                          ProcessorsType,
+                          std::filesystem::path,
+                          Path> {};
+
+} // namespace rfl::parsing

--- a/frontend/src/components/DrawerLayout.tsx
+++ b/frontend/src/components/DrawerLayout.tsx
@@ -22,7 +22,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 const triggerSync = async () => {
-    await axios.post("/api/sync");
+    await axios.post("/api/packages/sync");
 };
 
 export default () => {

--- a/frontend/src/components/SnapshotModal.tsx
+++ b/frontend/src/components/SnapshotModal.tsx
@@ -72,7 +72,7 @@ export default forwardRef<HTMLDialogElement, ISnapshotModalProps>(
                 return;
             }
             try {
-                await axios.post("/api/snap", {
+                await axios.post("/api/packages/snap", {
                     source: sourceSection,
                     target: targetSection
                 });

--- a/frontend/src/definitions/logEntry.d.ts
+++ b/frontend/src/definitions/logEntry.d.ts
@@ -7,7 +7,7 @@
 interface ILogEntry {
     id: string;
 
-    action: string;
+    type: string;
     package: IPackage;
     time: Date;
 }

--- a/frontend/src/definitions/package.d.ts
+++ b/frontend/src/definitions/package.d.ts
@@ -14,7 +14,7 @@ interface IPackage {
     section: ISection;
     name: string;
     isAnyArchitecture?: boolean;
-    preferredCandidate?: IPackagePoolEntry;
+    preferredLocation?: string;
     poolEntries?: {
         [key: string]: IPackagePoolEntry;
     };

--- a/frontend/src/hooks/BxtFsHooks.ts
+++ b/frontend/src/hooks/BxtFsHooks.ts
@@ -25,16 +25,13 @@ export const useFilesFromSections = (
     const [packages, setPackages] = useState<IPackage[]>();
 
     const getPackages = async (sections: ISection[], path: string[]) => {
-        const value = await axios.get(
-            `${process.env.PUBLIC_URL}/api/packages/get`,
-            {
-                params: {
-                    branch: path[1],
-                    repository: path[2],
-                    architecture: path[3]
-                }
+        const value = await axios.get(`/api/packages`, {
+            params: {
+                branch: path[1],
+                repository: path[2],
+                architecture: path[3]
             }
-        );
+        });
         if (value.data == null) {
             setFiles([]);
             setPackages(undefined);
@@ -43,20 +40,22 @@ export const useFilesFromSections = (
         setPackages(value.data);
 
         setFiles(
-            value.data.map(
-                (value: any): FileData => ({
-                    id: `root/${path[1]}/${path[2]}/${path[3]}/${value?.name}`,
-                    name: value.name,
+            value.data.map((pkg: any): FileData => {
+                console.log(pkg);
+                return {
+                    id: `root/${path[1]}/${path[2]}/${path[3]}/${pkg?.name}`,
+                    name: pkg.name,
                     ext: "",
                     isDir: false,
-                    thumbnailUrl:
-                        value?.preferredCandidate.hasSignature == "true"
+                    thumbnailUrl: pkg?.preferredLocation
+                        ? pkg?.poolEntries[pkg?.preferredLocation].hasSignature
                             ? `${process.env.PUBLIC_URL}/signature.svg`
-                            : `${process.env.PUBLIC_URL}/package.png`,
+                            : `${process.env.PUBLIC_URL}/package.png`
+                        : "",
                     icon: ChonkyIconName.archive,
                     color: "#8B756B"
-                })
-            )
+                };
+            })
         );
     };
 

--- a/frontend/src/hooks/BxtHooks.ts
+++ b/frontend/src/hooks/BxtHooks.ts
@@ -15,11 +15,9 @@ export const useSections = (): [ISection[], IUpdateSections] => {
     const [sections, setSections] = useState<ISection[]>([]);
 
     const updateSections: IUpdateSections = useCallback(() => {
-        axios
-            .get(`${process.env.PUBLIC_URL}/api/sections/get`)
-            .then((response) => {
-                setSections(response.data);
-            });
+        axios.get(`/api/sections`).then((response) => {
+            setSections(response.data);
+        });
     }, [setSections]);
 
     useEffect(() => {
@@ -74,8 +72,8 @@ export const useCompareResults = (): [
 
                 const compareEntries: ICompareEntry[] = [];
 
-                Object.keys(result.data["compare_table"]).forEach((value) => {
-                    const versions = { ...result.data["compare_table"] }[value];
+                Object.keys(result.data["compareTable"]).forEach((value) => {
+                    const versions = { ...result.data["compareTable"] }[value];
 
                     compareEntries.push({ name: value, ...versions });
                 });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -31,7 +31,7 @@ export default () => {
 
     const removeUser = useCallback(
         async (user: IUser) => {
-            await axios.post("/api/users/remove", { id: user.name });
+            await axios.post("/api/users/remove", { name: user.name });
             reloadUsers();
         },
         [reloadUsers]

--- a/frontend/src/pages/LogPage.tsx
+++ b/frontend/src/pages/LogPage.tsx
@@ -47,16 +47,28 @@ export default (props: any) => {
     const columnHelper = createColumnHelper<ILogEntry>();
 
     const columns = [
-        columnHelper.accessor("action", {
-            header: "Action"
+        columnHelper.accessor("type", {
+            header: "Type"
         }),
         columnHelper.accessor("package.name", {
             header: "Name"
         }),
 
-        columnHelper.accessor("package.preferredCandidate.version", {
-            header: "Version"
+        columnHelper.accessor("package.poolEntries", {
+            header: "Version",
+            cell: (context) => {
+                const value = context.getValue();
+                const preferredLocation =
+                    context?.row?.original?.package?.preferredLocation;
+
+                if (value && preferredLocation && value[preferredLocation]) {
+                    return value[preferredLocation].version;
+                } else {
+                    return "Unknown Version";
+                }
+            }
         }),
+
         columnHelper.accessor("package.section", {
             header: "Section",
             cell: (context) => <SectionLabel section={context.getValue()} />

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -27,7 +27,7 @@ export default (props: any) => {
     axios.interceptors.response.use(
         (response) => response,
         (error) => {
-            toast.error(`Response error: ${error.response?.data?.error}`, {
+            toast.error(`Response error: ${error.response?.data?.message}`, {
                 autoClose: false
             });
         }


### PR DESCRIPTION
This PR refactors and cleans up the whole public API by streamlining response creation and removing hand-crafted serialization in favour of `reflect-cpp` library and struct-based requests and responses.


@romangg code-wise it's complete and tested, only the OpenAPI config is not updated to represent these changes so feel free to review it

@fhdk this will break public API so keep an eye on it for the CLI version