### PR TITLE
Sync improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,3 +47,4 @@ conan_cmake_run(CONANFILE conanfile.txt
 
 add_subdirectory(daemon)
 add_subdirectory(frontend)
+add_subdirectory(dbcli)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -19,6 +19,7 @@ c-ares/1.19.1
 scnlib/1.1.2
 cereal/1.3.2
 libcoro/0.11.1
+scope-lite/0.2.0
 
 [generators]
 cmake

--- a/daemon/core/application/services/SyncService.h
+++ b/daemon/core/application/services/SyncService.h
@@ -7,17 +7,43 @@
 #pragma once
 
 #include "core/application/dtos/PackageSectionDTO.h"
+#include "utilities/Error.h"
+#include "utilities/errors/Macro.h"
 
 #include <coro/task.hpp>
+#include <frozen/string.h>
+#include <frozen/unordered_map.h>
 
 namespace bxt::Core::Application {
 
 class SyncService {
 public:
+    struct SyncError : public bxt::Error {
+        enum Type {
+            NetworkError,
+            IOError,
+            ParseError,
+            RepositoryError,
+            ValidationError
+        };
+        Type error_type;
+
+        SyncError(Type type) : error_type(type) {
+            message = type_messages.at(type).data();
+        }
+
+        static constexpr frozen::unordered_map<Type, frozen::string, 5>
+            type_messages {{NetworkError, "Network error occurred"},
+                           {IOError, "Input/output error occurred"},
+                           {ParseError, "Parsing error occurred"},
+                           {RepositoryError, "Repository error occurred"},
+                           {ValidationError, "Validation error occurred"}};
+    };
+    BXT_DECLARE_RESULT(SyncError)
     virtual ~SyncService() = default;
 
-    virtual coro::task<void> sync(const PackageSectionDTO section) = 0;
-    virtual coro::task<void> sync_all() = 0;
+    virtual coro::task<Result<void>> sync(const PackageSectionDTO section) = 0;
+    virtual coro::task<Result<void>> sync_all() = 0;
 };
 
 } // namespace bxt::Core::Application

--- a/daemon/core/domain/entities/Package.cpp
+++ b/daemon/core/domain/entities/Package.cpp
@@ -11,6 +11,7 @@
 #include "fmt/core.h"
 #include "scn/tuple_return/tuple_return.h"
 #include "utilities/Error.h"
+#include "utilities/alpmdb/Desc.h"
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -68,6 +69,11 @@ Package::Result<Package> Package::from_file_path(
     auto name = parse_file_name(filepath.filename());
 
     if (!name.has_value()) { return bxt::make_error<ParseError>(); }
+
+    auto desc = bxt::Utilities::AlpmDb::Desc::parse_package(filepath, false);
+    if (!desc.has_value()) {
+        return bxt::make_error_with_source<ParseError>(std::move(desc.error()));
+    }
 
     Package result(section, *name, false);
     result.pool_entries().emplace(location, *pool_entry);

--- a/daemon/core/domain/value_objects/PackageVersion.h
+++ b/daemon/core/domain/value_objects/PackageVersion.h
@@ -53,8 +53,8 @@ struct PackageVersion {
     std::string string() const;
 
     Name version;
-    std::optional<int> epoch = {};
-    std::string release;
+    Name epoch;
+    std::optional<Name> release = {};
 };
 
 } // namespace bxt::Core::Domain

--- a/daemon/infrastructure/alpm/ArchRepoSyncService.h
+++ b/daemon/infrastructure/alpm/ArchRepoSyncService.h
@@ -73,7 +73,7 @@ private:
     PackageRepositoryBase& m_package_repository;
 
     ArchRepoOptions m_options;
-    coro::io_scheduler tp {{.pool = {.thread_count = 4}}};
+    coro::io_scheduler tp {{.pool = {.thread_count = 1}}};
 };
 
 } // namespace bxt::Infrastructure

--- a/daemon/infrastructure/alpm/ArchRepoSyncService.h
+++ b/daemon/infrastructure/alpm/ArchRepoSyncService.h
@@ -7,15 +7,17 @@
 #pragma once
 
 #include "ArchRepoOptions.h"
-#include "boost/uuid/uuid.hpp"
 #include "core/application/services/SyncService.h"
 #include "core/domain/repositories/PackageRepositoryBase.h"
-#include "dexode/EventBus.hpp"
 #include "infrastructure/PackageFile.h"
+#include "utilities/Error.h"
 #include "utilities/eventbus/EventBusDispatcher.h"
 
+#include <boost/uuid/uuid.hpp>
+#include <coro/io_scheduler.hpp>
 #include <coro/thread_pool.hpp>
 #include <memory>
+#include <vector>
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
@@ -24,6 +26,17 @@ namespace bxt::Infrastructure {
 
 class ArchRepoSyncService : public bxt::Core::Application::SyncService {
 public:
+    struct DownloadError : public bxt::Error {
+        DownloadError(const std::string& package_filename,
+                      const std::string& error_message)
+            : package_filename(std::move(package_filename)) {
+            message = error_message;
+        }
+
+        std::string package_filename;
+    };
+    BXT_DECLARE_RESULT(DownloadError);
+
     ArchRepoSyncService(Utilities::EventBusDispatcher& dispatcher,
                         PackageRepositoryBase& package_repository,
                         ArchRepoOptions& options)
@@ -31,28 +44,33 @@ public:
           m_package_repository(package_repository),
           m_options(options) {}
 
-    virtual coro::task<void> sync(const PackageSectionDTO section) override;
-    virtual coro::task<void> sync_all() override;
+    coro::task<SyncService::Result<void>>
+        sync(const PackageSectionDTO section) override;
+    coro::task<SyncService::Result<void>> sync_all() override;
 
 protected:
-    coro::task<std::vector<Package>>
+    coro::task<SyncService::Result<std::vector<Package>>>
         sync_section(const PackageSectionDTO section);
 
-    coro::task<std::vector<std::string>>
+    coro::task<Result<std::vector<std::string>>>
         get_available_packages(const PackageSectionDTO section);
-    coro::task<PackageFile> download_package(PackageSectionDTO section,
-                                             std::string package_filename,
-                                             boost::uuids::uuid id);
+    coro::task<Result<PackageFile>>
+        download_package(PackageSectionDTO section,
+                         std::string package_filename,
+                         boost::uuids::uuid id);
 
     coro::task<std::unique_ptr<httplib::SSLClient>>
         get_client(const std::string url);
+
+    coro::task<std::optional<httplib::Result>> download_file(
+        std::string url, std::string path, std::string filename = "");
 
 private:
     Utilities::EventBusDispatcher& m_dispatcher;
     PackageRepositoryBase& m_package_repository;
 
     ArchRepoOptions m_options;
-    coro::thread_pool tp {coro::thread_pool::options {.thread_count = 4}};
+    coro::io_scheduler tp {{.pool = {.thread_count = 4}}};
 };
 
 } // namespace bxt::Infrastructure

--- a/daemon/infrastructure/alpm/ArchRepoSyncService.h
+++ b/daemon/infrastructure/alpm/ArchRepoSyncService.h
@@ -65,6 +65,9 @@ protected:
     coro::task<std::optional<httplib::Result>> download_file(
         std::string url, std::string path, std::string filename = "");
 
+    bool is_excluded(const PackageSectionDTO& section,
+                     const std::string& package_name) const;
+
 private:
     Utilities::EventBusDispatcher& m_dispatcher;
     PackageRepositoryBase& m_package_repository;

--- a/daemon/presentation/web-controllers/PackageController.cpp
+++ b/daemon/presentation/web-controllers/PackageController.cpp
@@ -32,8 +32,10 @@ using namespace drogon;
 drogon::Task<HttpResponsePtr>
     PackageController::sync(drogon::HttpRequestPtr req) {
     BXT_JWT_CHECK_PERMISSIONS("packages.sync", req)
-
-    co_await m_sync_service.sync_all();
+    drogon::async_run([this]() -> drogon::Task<void> {
+        co_await m_sync_service.sync_all();
+        co_return;
+    });
 
     co_return HttpResponse::newHttpResponse();
 }

--- a/daemon/utilities/alpmdb/Desc.cpp
+++ b/daemon/utilities/alpmdb/Desc.cpp
@@ -62,13 +62,16 @@ constexpr static frozen::set<frozen::string, 19> desc_keys {
 };
 
 namespace bxt::Utilities::AlpmDb {
-
 std::optional<std::string> Desc::get(const std::string &key) const {
     auto prepared_key = fmt::format("%{}%\n", key);
+    auto value_begin = desc.find(prepared_key);
 
-    auto value_begin = desc.find(prepared_key) + prepared_key.size();
+    if (value_begin == std::string::npos) { return {}; }
 
+    value_begin += prepared_key.size();
     auto value_end = desc.find("\n", value_begin);
+
+    if (value_end == std::string::npos) { return {}; }
 
     return desc.substr(value_begin, value_end - value_begin);
 }

--- a/daemon/utilities/alpmdb/Desc.h
+++ b/daemon/utilities/alpmdb/Desc.h
@@ -51,7 +51,8 @@ struct Desc {
 
     template<class Archive> void serialize(Archive& ar) { ar(desc, files); }
 
-    static Result<Desc> parse_package(const std::filesystem::path& filepath);
+    static Result<Desc> parse_package(const std::filesystem::path& filepath,
+                                      bool create_files = true);
 
     std::optional<std::string> get(const std::string& key) const;
 

--- a/dbcli/CMakeLists.txt
+++ b/dbcli/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(dbcli dbcli.cpp ../daemon/core/domain/enums/PoolLocation.cpp)
+
+target_link_libraries(dbcli PRIVATE ${CONAN_LIBS})
+
+target_include_directories(
+  dbcli PRIVATE ${CURL_INCLUDE_DIR} ${lmdbxx_SOURCE_DIR}/include ../daemon/)

--- a/dbcli/dbcli.cpp
+++ b/dbcli/dbcli.cpp
@@ -1,0 +1,108 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+#include "persistence/box/record/PackageRecord.h"
+#include "utilities/lmdb/CerealSerializer.h"
+
+#include <coro/io_scheduler.hpp>
+#include <coro/sync_wait.hpp>
+#include <cstdio>
+#include <fmt/core.h>
+#include <lmdbxx/lmdb++.h>
+#include <string>
+
+using Serializer = bxt::Utilities::LMDB::CerealSerializer<
+    bxt::Persistence::Box::PackageRecord>;
+
+int main(int argc, char** argv) {
+    auto lmdbenv = lmdb::env::create();
+
+    lmdbenv.set_mapsize(1UL * 1024UL * 1024UL * 1024UL);
+    lmdbenv.set_max_dbs(10);
+    std::error_code ec;
+
+    if (!std::filesystem::exists("./bxtd.lmdb", ec) || ec) {
+        fmt::print(stderr, "bxtd.lmdb not found\n");
+        return 1;
+    }
+
+    lmdbenv.open("./bxtd.lmdb");
+
+    auto transaction = lmdb::txn::begin(lmdbenv);
+    auto db = lmdb::dbi::open(transaction, "bxt::Box");
+
+    if (argc < 2) {
+        fmt::print("Usage: {} <command> [options]\n", argv[0]);
+        return 1;
+    }
+
+    std::string command = argv[1];
+    if (command == "list") {
+        auto cursor = lmdb::cursor::open(transaction, db);
+        if (argc >= 3) {
+            std::string_view key = argv[2];
+            if (!cursor.get(key, MDB_SET_RANGE) || !key.starts_with(argv[2])) {
+                fmt::print(stderr, "No packages found with prefix {}\n", key);
+                return 1;
+            }
+            do {
+                fmt::print("{}\n", key);
+            } while (cursor.get(key, MDB_NEXT) && key.starts_with(argv[2]));
+        } else {
+            std::string_view key;
+            while (cursor.get(key, MDB_NEXT)) {
+                fmt::print("{}\n", key);
+            }
+        }
+    } else if (command == "get") {
+        if (argc != 3) {
+            fmt::print(stderr, "Usage: {} get <key>\n", argv[0]);
+            return 1;
+        }
+
+        std::string key = argv[2];
+        std::string_view data;
+        auto result = db.get(transaction, key, data);
+        if (!result) {
+            fmt::print(stderr,
+                       "Failed to retrieve value or value not found.\n");
+            return 1;
+        }
+
+        const auto package = Serializer::deserialize(std::string(data));
+        if (!package.has_value()) {
+            fmt::print(stderr, "Failed to deserialize package.\n");
+            return 1;
+        }
+
+        fmt::print("{}\nIs any arch: {}\nDescriptions:\n",
+                   package->id.to_string(), package->is_any_architecture);
+        for (const auto& [key, value] : package->descriptions) {
+            fmt::print("==={}===\nFilepath: {}\nSignature path: "
+                       "{}\nDescfile:\n\n{}\n",
+                       bxt::to_string(key), value.filepath.string(),
+                       value.signature_path->string(), value.descfile.desc);
+        }
+    } else if (command == "del") {
+        if (argc != 3) {
+            fmt::print(stderr, "Usage: {} del <key>\n", argv[0]);
+            return 1;
+        }
+
+        std::string_view key = argv[2];
+        auto result = db.del(transaction, key);
+        if (result) {
+            fmt::print("Value deleted successfully.\n", argv[0]);
+        } else {
+            fmt::print(stderr, "Failed to delete value or value not found.\n");
+        }
+    } else {
+        fmt::print(stderr, "Unknown command: {}\n", command);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR improves overall previously half-baked sync service. It also includes

- `dbcli` dev utility to look through the LMDB packages database
- Sync exclude list support
- Fix for https://github.com/anydistro/bxt/issues/36
- Package version parsing logic follows the same logic as ALPM's one (logic I used from [ArchWiki](https://wiki.archlinux.org/title/PKGBUILD#pkgver) is incomplete, e.g. it doesn't say it allows `+` in package version)
- Improving package validation by checking it's descfile on adding

Those all are somewhat connected to the sync process but other subsystems will benefit as well.