### PR TITLE
Revamp commit UI/UX

### DIFF
--- a/frontend/src/components/CommitCard.tsx
+++ b/frontend/src/components/CommitCard.tsx
@@ -11,20 +11,25 @@ import {
     faTrashCan
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useMemo } from "react";
 import { Card, CardProps } from "react-daisyui";
 
-export type ICommitCardProps = CardProps & {
-    commit: ICommit;
-    onActivate?: (commit: ICommit) => void;
-    onDeleteRequested?: (id: string) => void;
+export type CommitCardProps = CardProps & {
+    section: ISection;
+    commit: Commit;
+    onActivate?: (section: ISection, commit: Commit) => void;
+    onDeleteRequested?: (section: ISection) => void;
 };
 
-export default (props: ICommitCardProps) => {
-    const section = props.commit.section;
+export default (props: CommitCardProps) => {
+    const { branch, repository, architecture } = useMemo(
+        () => props.section,
+        [props.section]
+    );
 
     return (
         <Card
-            onClick={() => props.onActivate?.(props.commit)}
+            onClick={() => props.onActivate?.(props.section, props.commit)}
             {...props}
             className="h-30 bg-white"
         >
@@ -33,22 +38,23 @@ export default (props: ICommitCardProps) => {
                     onClick={(e) => {
                         e.stopPropagation();
                         if (props.onDeleteRequested)
-                            return props.onDeleteRequested(props.commit.id);
+                            return props.onDeleteRequested(props.section);
                     }}
                     className="px-1"
                     icon={faTrashCan}
                 />
             </div>
             <Card.Body className="font-bold">
-                {props.commit.packages.length} packages
+                {props.commit.size} package
+                {props.commit.size == 1 ? "" : "s"}
             </Card.Body>
             <span className="space-x-4">
                 <FontAwesomeIcon className="px-1" icon={faCodeBranch} />
-                {section.branch}
+                {branch}
                 <FontAwesomeIcon className="px-1" icon={faCubes} />
-                {section.repository}
+                {repository}
                 <FontAwesomeIcon className="px-1" icon={faMicrochip} />
-                {section.architecture}
+                {architecture}
             </span>
         </Card>
     );

--- a/frontend/src/components/CommitDrawer.tsx
+++ b/frontend/src/components/CommitDrawer.tsx
@@ -1,0 +1,58 @@
+import { Button, Drawer, DrawerProps, Menu } from "react-daisyui";
+import CommitCard from "./CommitCard";
+import { SectionUtils } from "../utils/SectionUtils";
+
+type CommitDrawerProps = DrawerProps & {
+    isOpen: boolean;
+    commits: Commits;
+    onPush: (commits: Commits) => void;
+    onCardActivate: (section: ISection, commit: Commit) => void;
+    onCardDelete: (section: ISection) => void;
+};
+
+export default (props: CommitDrawerProps) => {
+    return (
+        <Drawer
+            {...props}
+            open={props.commits.size > 0 && props.isOpen}
+            contentClassName="fm-content h-full"
+            className="h-full"
+            side={
+                <div>
+                    <label
+                        htmlFor="my-drawer-2"
+                        className="drawer-overlay"
+                    ></label>
+                    <Menu className="h-screen p-4 w-100 space-y-4 bg-accent">
+                        <li className="text-3xl font-bold text-white">
+                            Pending commits
+                        </li>
+                        {Array.from(props.commits).map(([section, commit]) => {
+                            return (
+                                <Menu.Item>
+                                    <CommitCard
+                                        section={SectionUtils.fromString(
+                                            section
+                                        )}
+                                        onActivate={props.onCardActivate}
+                                        commit={commit}
+                                        onDeleteRequested={props.onCardDelete}
+                                    />
+                                </Menu.Item>
+                            );
+                        })}
+                        <div className="grow"></div>
+                        <Button
+                            color="ghost"
+                            className="text-white"
+                            onClick={(e) => props.onPush(props.commits)}
+                        >
+                            Push commits
+                        </Button>
+                    </Menu>
+                </div>
+            }
+            end={true}
+        />
+    );
+};

--- a/frontend/src/components/SectionSelect.tsx
+++ b/frontend/src/components/SectionSelect.tsx
@@ -10,11 +10,6 @@ import Select, {
     StylesConfig,
     components
 } from "react-select";
-import {
-    branches,
-    reposForBranch,
-    architecturesForBranchAndRepo
-} from "../utils/SectionUtils";
 import { HTMLAttributes, useCallback, useEffect } from "react";
 import {
     faCodeBranch,
@@ -25,6 +20,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as daisyui from "react-daisyui";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { ClassNamesArg } from "@emotion/react";
+import { SectionUtils } from "../utils/SectionUtils";
 
 type ISectionSelectorProps = HTMLAttributes<HTMLDivElement> & {
     sections: ISection[];
@@ -146,7 +142,7 @@ export default (props: ISectionSelectorProps) => {
                 components={makeComponents(faCodeBranch)}
                 styles={makeStyles(isDisabled(0))}
                 value={makeValue(props.selectedSection?.branch)}
-                options={branches(props.sections).map(makeValue)}
+                options={SectionUtils.branches(props.sections).map(makeValue)}
                 onChange={(value) => updateSection({ branch: value?.value })}
             />
             <Select<IOption>
@@ -154,7 +150,7 @@ export default (props: ISectionSelectorProps) => {
                 components={makeComponents(faCubes)}
                 styles={makeStyles(isDisabled(1))}
                 value={makeValue(props.selectedSection?.repository)}
-                options={reposForBranch(
+                options={SectionUtils.reposForBranch(
                     props.sections,
                     props.selectedSection?.branch
                 ).map(makeValue)}
@@ -167,7 +163,7 @@ export default (props: ISectionSelectorProps) => {
                 components={makeComponents(faMicrochip)}
                 styles={makeStyles(isDisabled(2))}
                 value={makeValue(props.selectedSection?.architecture)}
-                options={architecturesForBranchAndRepo(
+                options={SectionUtils.architecturesForBranchAndRepo(
                     props.sections,
                     props.selectedSection?.branch,
                     props.selectedSection?.repository

--- a/frontend/src/components/SnapshotModal.tsx
+++ b/frontend/src/components/SnapshotModal.tsx
@@ -13,7 +13,7 @@ import {
     useState
 } from "react";
 import { Button, Form, Modal, ModalProps, Select } from "react-daisyui";
-import { branches } from "../utils/SectionUtils";
+
 import { createPortal } from "react-dom";
 import axios from "axios";
 import SectionSelect from "./SectionSelect";

--- a/frontend/src/definitions/commit.d.ts
+++ b/frontend/src/definitions/commit.d.ts
@@ -4,8 +4,7 @@
  *   SPDX-License-Identifier: AGPL-3.0-or-later
  *
  */
-interface ICommit {
-    id: string;
-    section: ISection;
-    packages: IPackageUpload[];
-}
+
+type Commit = Map<string, Partial<IPackageUpload>>;
+
+type Commits = Map<string, Commit>;

--- a/frontend/src/hooks/BxtFsHooks.ts
+++ b/frontend/src/hooks/BxtFsHooks.ts
@@ -6,11 +6,7 @@
  */
 import { ChonkyIconName, FileArray, FileData } from "chonky";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-    architecturesForBranchAndRepo,
-    branches,
-    reposForBranch
-} from "../utils/SectionUtils";
+import { SectionUtils } from "../utils/SectionUtils";
 import axios from "axios";
 
 export interface IUpdateFiles {
@@ -64,20 +60,22 @@ export const useFilesFromSections = (
             switch (path.length) {
                 case 1:
                     setFiles(
-                        branches(sections).map((value): FileData => {
-                            return {
-                                id: `root/${value}`,
-                                name: value,
-                                isDir: true,
-                                thumbnailUrl: `${process.env.PUBLIC_URL}/branch.svg`,
-                                color: "#8B756B"
-                            };
-                        })
+                        SectionUtils.branches(sections).map(
+                            (value): FileData => {
+                                return {
+                                    id: `root/${value}`,
+                                    name: value,
+                                    isDir: true,
+                                    thumbnailUrl: `${process.env.PUBLIC_URL}/branch.svg`,
+                                    color: "#8B756B"
+                                };
+                            }
+                        )
                     );
                     break;
                 case 2:
                     setFiles(
-                        reposForBranch(sections, path[1]).map(
+                        SectionUtils.reposForBranch(sections, path[1]).map(
                             (value): FileData => {
                                 return {
                                     id: `root/${path[1]}/${value}`,
@@ -92,7 +90,7 @@ export const useFilesFromSections = (
                     break;
                 case 3:
                     setFiles(
-                        architecturesForBranchAndRepo(
+                        SectionUtils.architecturesForBranchAndRepo(
                             sections,
                             path[1],
                             path[2]

--- a/frontend/src/hooks/DragNDropHooks.ts
+++ b/frontend/src/hooks/DragNDropHooks.ts
@@ -1,0 +1,53 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+
+import { useCallback } from "react";
+import * as uuid from "uuid";
+
+export const usePackageDropHandler = (
+    path: string[],
+    setCommit: (commits: ICommit) => void
+) => {
+    return useCallback(
+        (acceptedFiles: File[]) => {
+            const section: ISection = {
+                branch: path[1],
+                repository: path[2],
+                architecture: path[3]
+            };
+            const packages: {
+                [key: string]: Partial<IPackageUpload>;
+            } = {};
+            for (const file of acceptedFiles) {
+                if (file.name.endsWith(".sig")) {
+                    const name = file.name.replace(".sig", "");
+                    if (!packages[name]) {
+                        packages[name] = {};
+                    }
+                    packages[name].signatureFile = file;
+                    continue;
+                }
+
+                packages[file.name] = {
+                    name: file.name,
+                    section,
+                    file: file,
+                    ...packages[file.name]
+                };
+            }
+
+            setCommit({
+                id: uuid.v4(),
+                section,
+                packages: Object.values(packages)
+                    .filter((partial) => partial as IPackageUpload)
+                    .map((partial) => partial as IPackageUpload)
+            });
+        },
+        [path, setCommit]
+    );
+};

--- a/frontend/src/hooks/DragNDropHooks.ts
+++ b/frontend/src/hooks/DragNDropHooks.ts
@@ -6,21 +6,16 @@
  */
 
 import { useCallback } from "react";
-import * as uuid from "uuid";
 
 export const usePackageDropHandler = (
-    path: string[],
-    setCommit: (commits: ICommit) => void
+    section: ISection | undefined,
+    addCommit: (section: ISection, commit: Commit) => void
 ) => {
     return useCallback(
         (acceptedFiles: File[]) => {
-            const section: ISection = {
-                branch: path[1],
-                repository: path[2],
-                architecture: path[3]
-            };
+            if (!section) return;
             const packages: {
-                [key: string]: Partial<IPackageUpload>;
+                [packageName: string]: Partial<IPackageUpload>;
             } = {};
             for (const file of acceptedFiles) {
                 if (file.name.endsWith(".sig")) {
@@ -40,14 +35,8 @@ export const usePackageDropHandler = (
                 };
             }
 
-            setCommit({
-                id: uuid.v4(),
-                section,
-                packages: Object.values(packages)
-                    .filter((partial) => partial as IPackageUpload)
-                    .map((partial) => partial as IPackageUpload)
-            });
+            addCommit(section, new Map(Object.entries(packages)));
         },
-        [path, setCommit]
+        [section, addCommit]
     );
 };

--- a/frontend/src/hooks/FileManagementHooks.ts
+++ b/frontend/src/hooks/FileManagementHooks.ts
@@ -1,0 +1,96 @@
+/* === This file is part of bxt ===
+ *
+ *   SPDX-FileCopyrightText: 2024 Artem Grinev <agrinev@manjaro.org>
+ *   SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ */
+
+import {
+    FileArray,
+    ChonkyFileActionData,
+    ChonkyActions,
+    FileHelper,
+    FileData
+} from "chonky";
+import { OpenFilesPayload } from "chonky/dist/types/action-payloads.types";
+import _ from "lodash";
+import { useCallback } from "react";
+import { SnapshotActionPayload } from "../components/SnapshotAction";
+
+export const useFolderChainForPath = (path: string[]): FileArray => {
+    const result: FileArray = [];
+
+    result.push({
+        id: "root",
+        name: "root",
+        isDir: true
+    });
+
+    for (let i = 1; i < path.length; i++) {
+        result.push({
+            id: `${result[i - 1]!.id}/${path[i]}`,
+            name: path[i],
+            isDir: true
+        });
+    }
+
+    return result;
+};
+
+export const packageFromFilePath = (filePath: string, packages: IPackage[]) => {
+    const parts = filePath.split("/");
+    if (parts.length != 5) return;
+    const section: ISection = {
+        branch: parts[1],
+        repository: parts[2],
+        architecture: parts[3]
+    };
+    const packageName = parts[4];
+
+    return packages.find((value) => {
+        return _.isEqual(value.section, section) && value.name == packageName;
+    });
+};
+
+export const useFileActionHandler = (
+    setPath: (path: string[]) => void,
+    setSnapshotModalBranches: (
+        sourceBranch?: string,
+        targetBranch?: string
+    ) => void,
+    setPackage: (pkg?: IPackage) => void,
+    packages: IPackage[]
+) => {
+    return useCallback(
+        (data: ChonkyFileActionData) => {
+            switch (data.id as string) {
+                case ChonkyActions.OpenFiles.id:
+                    const { targetFile, files } =
+                        data.payload as OpenFilesPayload;
+                    const fileToOpen = targetFile ?? files[0];
+                    if (fileToOpen && FileHelper.isDirectory(fileToOpen)) {
+                        const pathToOpen = fileToOpen.id.split("/");
+
+                        setPath(pathToOpen);
+                    } else if (
+                        fileToOpen &&
+                        !FileHelper.isDirectory(fileToOpen)
+                    ) {
+                        setPackage(
+                            packageFromFilePath(
+                                (fileToOpen as FileData).id,
+                                packages
+                            )
+                        );
+                    }
+                    break;
+                case "snap":
+                    const { sourceBranch, targetBranch } =
+                        data.payload as SnapshotActionPayload;
+
+                    setSnapshotModalBranches(sourceBranch, targetBranch);
+            }
+        },
+        [setPath, setSnapshotModalBranches, setPackage, packages]
+    );
+};

--- a/frontend/src/utils/SectionUtils.ts
+++ b/frontend/src/utils/SectionUtils.ts
@@ -5,50 +5,80 @@
  *
  */
 
-const filteredValues = (
-    sections: ISection[],
-    filterFunction: (section: ISection) => boolean,
-    valueExtractor: (section: ISection) => string | undefined
-): string[] => {
-    const valueSet = new Set<string>();
-    sections.forEach((section) => {
-        if (filterFunction(section)) {
-            const value = valueExtractor(section);
-            if (value) valueSet.add(value);
-        }
-    });
+export module SectionUtils {
+    const filteredValues = (
+        sections: ISection[],
+        filterFunction: (section: ISection) => boolean,
+        valueExtractor: (section: ISection) => string | undefined
+    ): string[] => {
+        const valueSet = new Set<string>();
+        sections.forEach((section) => {
+            if (filterFunction(section)) {
+                const value = valueExtractor(section);
+                if (value) valueSet.add(value);
+            }
+        });
 
-    return Array.from(valueSet);
-};
+        return Array.from(valueSet);
+    };
 
-export const branches = (sections: ISection[]): string[] => {
-    return filteredValues(
-        sections,
-        () => true,
-        (section) => section.branch
-    );
-};
+    export const branches = (sections: ISection[]): string[] => {
+        return filteredValues(
+            sections,
+            () => true,
+            (section) => section.branch
+        );
+    };
 
-export const reposForBranch = (
-    sections: ISection[],
-    branchName: string | undefined
-): string[] => {
-    return filteredValues(
-        sections,
-        (section) => section.branch === branchName,
-        (section) => section.repository
-    );
-};
+    export const reposForBranch = (
+        sections: ISection[],
+        branchName: string | undefined
+    ): string[] => {
+        return filteredValues(
+            sections,
+            (section) => section.branch === branchName,
+            (section) => section.repository
+        );
+    };
 
-export const architecturesForBranchAndRepo = (
-    sections: ISection[],
-    branchName: string | undefined,
-    repoName: string | undefined
-): string[] => {
-    return filteredValues(
-        sections,
-        (section) =>
-            section.branch === branchName && section.repository === repoName,
-        (section) => section.architecture
-    );
-};
+    export const architecturesForBranchAndRepo = (
+        sections: ISection[],
+        branchName: string | undefined,
+        repoName: string | undefined
+    ): string[] => {
+        return filteredValues(
+            sections,
+            (section) =>
+                section.branch === branchName &&
+                section.repository === repoName,
+            (section) => section.architecture
+        );
+    };
+
+    export const toString = (section: ISection): string => {
+        return `${section.branch}/${section.repository}/${section.architecture}`;
+    };
+
+    export const fromString = (sectionString: string): ISection => {
+        const [branch, repo, arch] = sectionString.split("/");
+        return { branch, repository: repo, architecture: arch };
+    };
+
+    export const toPath = (section: ISection): string[] => {
+        return [
+            "root",
+            section.branch || "",
+            section.repository || "",
+            section.architecture || ""
+        ];
+    };
+
+    export const fromPath = (path: string[]): ISection | undefined => {
+        if (path.length < 4 && path[0] !== "root") return undefined;
+        return {
+            branch: path[1],
+            repository: path[2],
+            architecture: path[3]
+        };
+    };
+}


### PR DESCRIPTION
This PR aims to improve the UX of commiting process by making commit dialogs more flexible, allowing users to:

- Commit into multiple sections at push
- Commit packages one by one instead of requiring drag-n-dropping all packages at once


<img width="1440" alt="Снимок экрана 2024-05-29 в 15 33 38" src="https://github.com/anydistro/bxt/assets/7955026/cd16452b-c6ce-4461-bf2b-c531c9564e2b">
<img width="1440" alt="Снимок экрана 2024-05-29 в 15 32 58" src="https://github.com/anydistro/bxt/assets/7955026/bbe7ae9a-6c8c-4512-a8f0-62e9a3da545a">
<img width="1440" alt="Снимок экрана 2024-05-29 в 15 32 32" src="https://github.com/anydistro/bxt/assets/7955026/563a54dc-31dd-4ca8-971d-89df416dd047">