### PR TITLE
Cache Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
-      - name: Build production environment using docker-compose
-        run: |
-          docker compose -f docker-compose.yml -f docker-compose.caddy.yml build production
 
-      - name: Save Docker image as a tarball
-        run: docker save bxt_production:latest -o bxt-production.tar
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          target: production
+          tags: anydistro/bxt:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=./bxt-production.tar
 
       - name: Upload Docker image to artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use Docker's build-push-action. This allows to cache the Docker layers, significantly speeding up builds. We also don't need a separate save step anymore.

Closes #87 