### PR TITLE
Check Clang-Tidy in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,14 @@
-Checks: "-*,modernize-*,cppcoreguidelines-*, -modernize-use-nodiscard, -modernize-use-trailing-return-type"
+WarningsAsErrors: "readability-braces-around-statements"
+
+Checks: "
+-*,
+modernize-*,
+cppcoreguidelines-*,
+readability-braces-around-statements,
+-modernize-use-nodiscard,
+-modernize-use-trailing-return-type
+"
+
 CheckOptions:
   - key: modernize-use-nullptr.NullMacros
     value: "NULL"

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,25 @@
+name: Static Analysis
+on: workflow_call
+
+jobs:
+  clang-tidy:
+    name: Check clang-tidy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Docker image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bxt-development-image
+          path: distfiles
+      - name: Load Docker image
+        run: docker load -i distfiles/bxt-development.tar
+      - uses: addnab/docker-run-action@v3
+        with:
+          image: anydistro/bxt-development:latest
+          options: -v ${{ github.workspace }}:/src
+          run: |
+            ls /src
+            cmake -S /src --preset clang-tidy
+            cmake --build /src/build/clang-tidy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,15 @@
-name: Build and deploy to testing server
-on: workflow_call
+name: Build Docker Image
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: List of tags of the resulting Docker image
+        required: true
+        type: string
+      target:
+        description: Sets the target stage to build
+        required: true
+        type: string
 
 jobs:
   build-docker:
@@ -16,54 +26,17 @@ jobs:
         with:
           context: .
           push: false
-          target: production
-          tags: anydistro/bxt:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          outputs: type=docker,dest=./bxt-production.tar
+          target: ${{ inputs.target }}
+          tags: ${{ inputs.tags }}
+          cache-from: type=gha,scope=${{ inputs.target }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.target }}
+          outputs: type=docker,dest=./bxt-${{ inputs.target }}.tar
 
       - name: Upload Docker image to artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: bxt-production-image
+          name: bxt-${{ inputs.target }}-image
           path: |
-            bxt-production.tar
+            bxt-${{ inputs.target }}.tar
             docker-compose.yml
             docker-compose.caddy.yml
-
-  deploy-ssh:
-    name: Deploy to server using ssh
-    needs: build-docker
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.repository == 'anydistro/bxt'
-
-    steps:
-      - name: Download Docker image from artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: bxt-production-image
-          path: distfiles
-
-      - name: Transfer Docker image to server
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
-          username: ${{ secrets.DEPLOYMENT_SERVER_USER }}
-          key: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}
-          source: distfiles/*
-          target: "/tmp/bxt/"
-
-      - name: Deploy Docker image on server
-        uses: appleboy/ssh-action@v1.0.3
-        env:
-          CADDY_HOST: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
-        with:
-          host: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
-          username: ${{ secrets.DEPLOYMENT_SERVER_USER }}
-          key: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}
-          envs: CADDY_HOST
-          script: |
-            cd /tmp/bxt/distfiles/
-            docker compose -f docker-compose.yml -f docker-compose.caddy.yml down production || true
-            docker load -i bxt-production.tar
-            docker compose -f docker-compose.yml -f docker-compose.caddy.yml -p bxt up -d production

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -4,6 +4,7 @@ name: CI
 on:
   - push
   - pull_request
+
 jobs:
   message-lint:
     uses: ./.github/workflows/commit-lint.yml
@@ -11,6 +12,25 @@ jobs:
       upstream-repo: https://github.com/anydistro/bxt.git
   check-format:
     uses: ./.github/workflows/check-format.yml
-  build:
+
+  prod-build:
     uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      tags: anydistro/bxt:latest
+      target: production
+  dev-build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      tags: anydistro/bxt-development:latest
+      target: development
+
+  analysis:
+    uses: ./.github/workflows/analysis.yml
+    needs: dev-build
+    secrets: inherit
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    needs: prod-build
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Docker Image to Server
+on: workflow_call
+
+jobs:
+  deploy-ssh:
+    name: SSH to testing server
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.repository == 'anydistro/bxt'
+
+    steps:
+      - name: Download Docker image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bxt-production-image
+          path: distfiles
+
+      - name: Transfer Docker image to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
+          username: ${{ secrets.DEPLOYMENT_SERVER_USER }}
+          key: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}
+          source: distfiles/*
+          target: "/tmp/bxt/"
+
+      - name: Deploy Docker image on server
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          CADDY_HOST: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
+        with:
+          host: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
+          username: ${{ secrets.DEPLOYMENT_SERVER_USER }}
+          key: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}
+          envs: CADDY_HOST
+          script: |
+            cd /tmp/bxt/distfiles/
+            docker compose -f docker-compose.yml -f docker-compose.caddy.yml down production || true
+            docker load -i bxt-production.tar
+            docker compose -f docker-compose.yml -f docker-compose.caddy.yml -p bxt up -d production

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,20 @@ include("${CMAKE_SOURCE_DIR}/cmake/bundled-deps.cmake")
 ################################################################################
 include("${CMAKE_SOURCE_DIR}/cmake/deps.cmake")
 
+################################################################################
+# Static Analysis: Enable Clang-Tidy
+################################################################################
+option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" OFF)
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy clang-tidy-18)
+
+    if(CLANG_TIDY_EXE)
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-header-filter=${CMAKE_SOURCE_DIR}/daemon/.*")
+    message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+    else()
+    message(SEND_ERROR "clang-tidy not found.")
+    endif()
+endif()
 
 ################################################################################
 # Project Structure: Add subdirectories for different components

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,15 @@
       "name": "debug",
       "inherits": "base",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "clang-tidy",
+      "inherits": "debug",
+      "cacheVariables": {
+        "ENABLE_CLANG_TIDY": "ON"
       }
     },
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: MIT
 
 ## Dev Setup
 ### Prerequisits
-- Docker or Podman (not tested)
+- Docker with Buildx or Podman (not tested)
 - For VS Code the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 
 ### VS Code

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,10 @@ ENV PATH="/root/.bun/bin:/root/.local/bin:${PATH}"
 RUN pipx install conan==2.7.0
 
 RUN conan profile detect --force --name default && \
-    cat <<EOF >> /root/.conan2/profiles/default 
-compiler=clang 
-compiler.version=18 
-compiler.libcxx=libc++ 
+    cat <<EOF >> /root/.conan2/profiles/default
+compiler=clang
+compiler.version=18
+compiler.libcxx=libc++
 compiler.cppstd=23
 EOF
 
@@ -75,7 +75,7 @@ FROM base as development
 
 RUN conan install /conan -pr=/root/.conan2/profiles/default  -s build_type=Debug --build=missing -of /conan
 # for main application
-EXPOSE 8080 
+EXPOSE 8080
 # for web server
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ apt-get install --yes \
     build-essential \
     clang-18 \
     clang-format-18 \
+    clang-tidy-18 \
     clangd-18 \
     cmake \
     curl \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains following projects:
 - **daemon**: a server side backend application that handles all the repository work aspects.
 - **frontend**: a client web application allowing users to interact with the server in a convenient manner.
 
-### Features:
+## Features
 
 - **Clear Structure**: Box consists of sections, a branch/repository/architecture triplet (e.g., stable/core/x86_64) allowing straightforward navigation in a file manager-like UI;
 - **Simple Package Management**: packages can be added, removed and updated using a plain drag-and-drop;
@@ -28,9 +28,9 @@ This repository contains following projects:
 - **User Management**: bxt is made to have a hierarchical multi-user system with per-user granular permission control;
 - **Candidates System**: the package's source (either sync or manual/automatic push) preference is fully configurable;
 
-### Setup:
+## Setup
 
-To build and run this application you can use Docker
+To build and run this application you can use Docker (with Buildx):
 
 ```bash
 # copy example configs

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class BxtConanFile(ConanFile):
         # to link to them you need to change cmake/deps.cmake
         self.requires("openssl/3.3.1")
         self.requires("boost/1.83.0")
-        self.requires("date/3.0.1") # Use until LLVM libc++ gets chrono::from_stream and chrono::to_stream support 
+        self.requires("date/3.0.1") # Use until LLVM libc++ gets chrono::from_stream and chrono::to_stream support
         self.requires("fmt/11.0.2")
         self.requires("frozen/1.2.0")
         self.requires("yaml-cpp/0.8.0")
@@ -36,5 +36,5 @@ class BxtConanFile(ConanFile):
          for dep in self.dependencies.values():
             if not dep.cpp_info.libdirs:
                 continue
-            copy(self, "*.so*", dep.cpp_info.libdirs[0], 
+            copy(self, "*.so*", dep.cpp_info.libdirs[0],
                                 os.path.join(self.build_folder, "../bin/lib"))

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,0 +1,7 @@
+# Developer Tooling
+
+The Clang-Tidy helper script can be run on an already existing development build in a dev container with:
+
+```
+/bin/python3 /workspaces/source/tooling/clang-tidy.py -p /workspaces/source/build/debug -clang-version 18 -header-filter=/workspaces/source/daemon/.*
+```

--- a/tooling/clang-tidy.py
+++ b/tooling/clang-tidy.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2024 Roman Gilg <subdiff@gmail.com>
+# SPDX-License-Identifier: MIT
+
+import argparse, os, subprocess, sys, tempfile
+from shutil import which
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+source_dir = os.path.dirname(os.path.dirname(script_dir))
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Run clang-tidy script with additional options"
+    )
+    parser.add_argument(
+        "-p",
+        dest="build_path",
+        required=True,
+        help="path used to read a compile command database",
+    )
+    parser.add_argument(
+        "-j",
+        type=int,
+        default=0,
+        help="number of tidy instances to be run in parallel",
+    )
+    parser.add_argument(
+        "-clang-version",
+        dest="clang_version",
+        type=int,
+        default=-1,
+        help="clang-version to use (defaults to development version)",
+    )
+    parser.add_argument(
+        "-clang-tidy-binary",
+        dest="clang_tidy_path",
+        default="",
+        help="path to clant-tidy binary",
+    )
+    parser.add_argument(
+        "-header-filter",
+        dest="header_filter",
+        default=".*",
+        help="regular expression matching the names of the headers to output diagnostics from",
+    )
+    return parser.parse_args()
+
+
+args = parse_arguments()
+os.chdir(source_dir)
+
+
+def get_binary_args():
+    add_args = ["-clang-tidy-binary"]
+
+    if args.clang_tidy_path:
+        return add_args + [args.clang_tidy_path]
+
+    if args.clang_version > 0:
+        versioned_path = which("clang-tidy-" + str(args.clang_version))
+        if versioned_path is not None:
+            return add_args + [versioned_path]
+    return []
+
+
+# Additional arguments for run-clang-tidy.py
+additional_args = [
+    "-use-color",
+    "-j",
+    str(args.j),
+    "-p=" + args.build_path,
+    "-header-filter=" + args.header_filter,
+]
+additional_args += get_binary_args()
+
+if args.clang_version > 0:
+    run_script_url = (
+        "https://raw.githubusercontent.com/llvm/llvm-project/release/"
+        + str(args.clang_version)
+        + ".x/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py"
+    )
+else:
+    run_script_url = "https://raw.githubusercontent.com/llvm/llvm-project/main/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py"
+
+# Download the run-clang-tidy.py script and save it as a temporary file
+with tempfile.NamedTemporaryFile(mode="w") as temp_file:
+    curl_process = subprocess.Popen(["curl", "-s", run_script_url], stdout=temp_file)
+    curl_process.wait()
+    run_clang_tidy_script_path = temp_file.name
+
+    # Execute the modified script using Python with additional arguments
+    python_process = subprocess.Popen(
+        [sys.executable, run_clang_tidy_script_path] + additional_args + [source_dir],
+        stdin=subprocess.PIPE,
+    )
+    python_process.communicate()
+    exit(python_process.returncode)


### PR DESCRIPTION
Clang-Tidy is checked now on every CI run. Additionally a Python script is added with which a developer can run Clang-Tidy on an already existing development build and has a nicer output.

As of now only a single check is marked to fail not only with a warning but with an error. In the future we want to increase the number of checks that let the pipeline fail when they fail. But for that we need to create additional bug fixes what can be done in follow-up PRs.