### PR TITLE
fix(daemon): fix package name parsing logic

### DIFF
--- a/daemon/core/domain/entities/Package.cpp
+++ b/daemon/core/domain/entities/Package.cpp
@@ -14,6 +14,7 @@
 #include "utilities/Error.h"
 
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <cctype>
 #include <filesystem>
@@ -48,16 +49,18 @@ bool check_valid_name(std::string_view name) {
 namespace bxt::Core::Domain {
 
 std::optional<std::string> Package::parse_file_name(std::string const& filename) {
+    auto pkg_name = filename.substr(0, filename.find(".pkg.tar"));
+
     std::vector<std::string> substrings;
-    boost::split(substrings, filename, boost::is_any_of("-"));
+    boost::split(substrings, pkg_name, boost::is_any_of("-"));
 
     if (substrings.size() < 4) {
         return {};
     }
 
-    auto version_pos = filename.find(substrings[substrings.size() - 3]);
-    std::string name = filename.substr(0, version_pos - 1);
+    auto name_parts = std::vector<std::string>(substrings.begin(), substrings.end() - 3);
 
+    std::string name = boost::join(name_parts, "-");
     if (!check_valid_name(name)) {
         return {};
     }

--- a/daemon/tests/src/unit/core/domain/entities/PackageTest.cpp
+++ b/daemon/tests/src/unit/core/domain/entities/PackageTest.cpp
@@ -17,6 +17,10 @@ TEST_CASE("Package", "[core][domain][entities]") {
         REQUIRE(Package::parse_file_name("package-1.0.0-1-any.pkg.tar.zst").value() == "package");
         REQUIRE(Package::parse_file_name("lib32-package-1.0.0-1-x86_64.pkg.tar.zst").value()
                 == "lib32-package");
+        REQUIRE(Package::parse_file_name("autoconf2.13-2.13-8-any.pkg.tar.zst").value()
+                == "autoconf2.13");
+        REQUIRE(Package::parse_file_name("lib32-libudev0-shim-2-1-x86_64.pkg.tar.zst").value()
+                == "lib32-libudev0-shim");
 
         // Invalid cases
         REQUIRE(Package::parse_file_name("package.pkg.tar.zst") == std::nullopt);


### PR DESCRIPTION
Fixes #115. Also covers these two cases with tests.